### PR TITLE
Eintrag "mediapool_focuspoint_preview" in den .lang-Dateien ergänzt

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -34,6 +34,7 @@ media_manager_effekt_focuspointfit_fp_inherit = Nur allgemeiner Bezugspunkt
 media_manager_effekt_focuspointfit_fp_pic = Fokuspunkt des Bildes, Fallback allgemeiner Bezugspunkt
 
 mediapool_focuspoint_reset = Focuspoint zurücksetzen
+mediapool_focuspoint_preview = Vorschau
 
 rex_effect_focuspoint_fit = Bild: Focuspoint fit
 rex_effect_focuspoint_resize = Bild: Focuspoint resize

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -35,6 +35,7 @@ media_manager_effekt_focuspointfit_fp_inherit = general focuspoint only
 media_manager_effekt_focuspointfit_fp_pic = picture-individual focuspoint first, fallback to general focuspoint
 
 mediapool_focuspoint_reset = reset Focuspoint
+mediapool_focuspoint_preview = Preview
 
 rex_effect_focuspoint_fit = Image: Focuspoint fit
 rex_effect_focuspoint_resize = Image: Focuspoint resize

--- a/lang/pt_br.lang
+++ b/lang/pt_br.lang
@@ -19,3 +19,5 @@ media_manager_effect_crop_position = Ponto de referência
 
 rex_effect_focuspoint_fit = Retrato: Focuspoint fit
 rex_effect_focuspoint_resize = Retrato: Focuspoint resize
+
+mediapool_focuspoint_preview = Visualização

--- a/lang/sv_se.lang
+++ b/lang/sv_se.lang
@@ -35,6 +35,7 @@ media_manager_effekt_focuspointfit_fp_inherit = Endast allmän fokuspunkt
 media_manager_effekt_focuspointfit_fp_pic = Bild-individuell fokuspunkt först, fallback till allmän fokuspunkt
 
 mediapool_focuspoint_reset = Aterställ focuspoint till standard
+mediapool_focuspoint_preview = förhandsvisning
 
 rex_effect_focuspoint_fit = Bild: Focuspoint fit
 rex_effect_focuspoint_resize = Bild: Focuspoint resize


### PR DESCRIPTION
Der lang-Eintrag für den Preview-Button fehlte noch. Ergänzt in alen 4 Sprachdateien. Tw. mangels Sprachkenntnis (pt_br und sv_se) auf Google-Basis :-) 