### PR TITLE
V2.0.1: Fehler in update.php behoben

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## **03.09.2018 Version 2.0.1**
+
+- Bugfix: Update-Fehler behoben (Zoom-Faktor des Fit-Effekt wurde nicht übernommen).
+
 ## **30.08.2018 Version 2.0.0**
 
 **ein komplett neu entwickeltes Major-Release**
@@ -71,60 +75,61 @@
     - Anleitung für den Umstieg
     - Auszüge zum Fit-Effekt in den Media-Manager eingehängt
 
-**24.03.2018 Version 1.4.2**
+
+## **24.03.2018 Version 1.4.2**
 
 - Vorschau nur wenn Mediatyp einen Focuspoint-Effekt besitzt (thx @eaCe)
 
-**07.03.2018 Version 1.4.1**
+## **07.03.2018 Version 1.4.1**
 
 - Update class.rex_effect_focuspoint_fit.php #39
 
-**06.03.2018 Version 1.4.0**
+## **06.03.2018 Version 1.4.0**
 
 - Nicht-Statische Methode nicht statisch aufrufen… Danke @tbaddade
 - initialize class outside of loop...
 - Eintrag "mediapool_focuspoint_preview" in den .lang-Dateien ergänzt
 
-**23.01.2018 Version 1.3.30**
+## **23.01.2018 Version 1.3.30**
 
 - Bildformat als Aspect-Ratio und input-check mit Pattern (#34)
 
-**17.12.2017 Version 1.3.20**
+## **17.12.2017 Version 1.3.20**
 
 - Vorschau für Mediatypen hinzugefügt (#30)
 
-**14.12.2017 Version 1.3.12**
+## **14.12.2017 Version 1.3.12**
 
 - Inputfelder bei Upload/Sync versteckt (#25)
 
-**24.11.2017 Version 1.3.11**
+## **24.11.2017 Version 1.3.11**
 
 - Media Manager Effekte umbenannt (#29)
 
-**24.11.2017 Version 1.3.10**
+## **24.11.2017 Version 1.3.10**
 
 - rex_sql_exception bei abweichendem tabellen-prefix behoben (#28)
 - README erweitert
 
-**17.11.2017 Version 1.3.9**
+## **17.11.2017 Version 1.3.9**
 
 - Menülink unter AddOns entfernt (#27)
 
-**08.08.2017 Version 1.3.8**
+## **08.08.2017 Version 1.3.8**
 
 - Minimale CSS Anpassung
 
-**17.07.2017 Version 1.3.7**
+## **17.07.2017 Version 1.3.7**
 
 - Focuspoint wird nun auch initialisiert, wenn die Bilddetailansicht von einem Media Widget aus geöffnet wird (dann wird der Dateiname statt der Datei Id übergeben) (IngoWinter)
 
 
-**17.07.2017 Version 1.3.6**
+## **17.07.2017 Version 1.3.6**
 
 - reset Focuspoint Link (IngoWinter)
 
 
-**07.03.2017 Version 1.3.5**
+## **07.03.2017 Version 1.3.5**
 
 - Neuer Effekt: focuspoint_fit (christophboecker)
 - Unterstützung von jpeg Dateien (tbaddade / skerbis)
@@ -132,45 +137,45 @@
 - "Target"-Image ausgetauscht
 
 
-**07.03.2017 Version 1.3.3**
+## **07.03.2017 Version 1.3.3**
 
 - Feldzuordnung korrigiert. Danke an [Norbert](https://github.com/tyrant88)
 
 ---
 
-**25.02.2017 Version 1.3.2**
+## **25.02.2017 Version 1.3.2**
 
 - Update en_gb.lang - Danke an @ynamite!
 
 ---
 
-**14.10.2016 Version 1.3.1**
+## **14.10.2016 Version 1.3.1**
 
 - CSS Augabewert angepasst (Komma)
 
 ___
 
-**11.10.2016 Version 1.3**
+## **11.10.2016 Version 1.3**
 
 - Umzug zu FoR
 
 ___
 
-**17.03.2016 Version 1.2**
+## **17.03.2016 Version 1.2**
 
 - Bild im Medienpool wird jetzt nicht mehr in der Originalgröße benutzt
   (Danke an Roman Huy-Prech für die Anpassung)
 
 ___
 
-**02.03.2016 Version 1.0**
+## **02.03.2016 Version 1.0**
 
 - Media Manager Effekt für REX5 angepasst
 
 ___
 
 
-**29.02.2016 Version 0.5**
+## **29.02.2016 Version 0.5**
 
 - Anpassungen an Redaxo 5
 

--- a/docs/de_de/changes_2_0.md
+++ b/docs/de_de/changes_2_0.md
@@ -39,7 +39,7 @@ $fp = "$x%,$y%";                                // Verwendung
 
 ### Feld: med_focuspoint_data
 
-Für dieses Feld lag der Koordinatenursprung genau in der Bildmitte, die Koordinaten waren ein
+Für dieses Feld lag der Koordinatenursprung genau in der Bildmitte; die Koordinaten waren ein
 Wert zwischen -1 (links bzw. unten) und 1 (rechts bzw. oben).
 
 - alt: 0.0,-0.2

--- a/docs/de_de/developer.md
+++ b/docs/de_de/developer.md
@@ -28,7 +28,7 @@ Die Parameter sind:
 - `true` zur Umrechnung der relativen in absolute Koordinaten auf Basis der Bildgröße. Vorgabe: `false`. Man kann statt `true` auch eine eigene Bildgröße als Array `[«breite»,«höhe»]` angeben.
 
 Falls das angegebene Fokuspunkt-Metafeld nicht existiert, wird nicht auf das Default-Feld
-zurückgegriffen, sondernn der Fallback-Wert herangezogen.
+zurückgegriffen, sondern der Fallback-Wert herangezogen.
 
 Die Klasse `focuspoint_media` kann z.B. in eigenen Effekten, die auf Fokuspunkten basieren,
 eingesetzt werden, aber auch in beliebigen anderen Zusammenhängen. Hier ein Beispiel :
@@ -155,7 +155,7 @@ auf den Fallback-Wert verwiesen wird (`default`), wird ein leerer String zurück
 
 Die Funktion ermittelt den für das Bild relevanten Fokuspunkt direkt aus dem Bild.
 Das mit getMetaField() ermittelte Metafeld wird aus dem Bild abgefragt.
-Wenn das Feld nicht gelesenwerrden kann bzw. nicht gefunden wird oder wenn der Wert im Feld keine
+Wenn das Feld nicht gelesen werden kann bzw. nicht gefunden wird oder wenn der Wert im Feld keine
 gültige Koordinate ist, wird `$default` zurückgegeben. Wenn `$default` nicht angegeben ist, wird
 `[50,50]` zurückgegeben (also Bildmitte).
 
@@ -168,10 +168,10 @@ if ( $fpMedia )
 ```
 
 ### array function **getParams**()
-Die Methode iefert für den Parametrisierungsdialog eines Fokuspunkt-Effektes das
+Die Methode liefert für den Parametrisierungsdialog eines Fokuspunkt-Effektes das
 Grundgerüst mit zwei Feldern:
 
-- Auswahl des heranzuziehenden Meta-Feldes (`meta`)
+- Auswahl des heranzuziehenden Metafeldes (`meta`)
 - Default-Koordinate (`focus`)
 
 Eigene, weitergehende Parameter-Felder könne per `array_merge` hinzugefügt werden:

--- a/docs/de_de/install.md
+++ b/docs/de_de/install.md
@@ -27,7 +27,7 @@ Sollte es bereits ein Meta-Feld `med_focuspoint` geben, das einen anderen Feldty
 Installation abgebrochen. Das Feld muss zuerst gelöscht oder umbenannt werden.
 
 Sollte es bereits einen Media-Manager-Typ `focuspoint_media_detail` geben, wird lediglich der
-demit verbundene Effekt reinitialisiert.
+damit verbundene Effekt reinitialisiert.
 
 <a name="manage-reinstall"></a>
 ## Re-Installieren

--- a/docs/de_de/media_edit.md
+++ b/docs/de_de/media_edit.md
@@ -5,7 +5,7 @@ erfolgt in der Detailansicht des Medienpools:
 
 ![medianpool](edit01.jpg)
 
-Rechts neben dem Eingabereiche wird das Bid angezeigt (roter Rahmen). Im und um das Bild sind
+Rechts neben dem Eingabereich wird das Bid angezeigt (roter Rahmen). Im und um das Bild sind
 Bedienelemente, mit denen der Fokuspunkt bequem [interaktiv](#media_edit_interactive.md) ausgewählt werden kann.
 
 Die Datenfelder für Fokuspunkte (mit einem roten Pfeil markiert) sind zudem im linken Eingebereich

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package:  focuspoint
-version:  '2.0.0-dev'
+version:  '2.0.1'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/focuspoint
 

--- a/update.php
+++ b/update.php
@@ -132,6 +132,14 @@ if (rex_string::versionCompare($this->getVersion(), '2.0', '<'))
                                 : rex_effect_abstract_focuspoint::MED_DEFAULT;
                             unset( $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_fp'] );
                         }
+                        if( isset($v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom']) &&
+                            preg_match( '(0%|25%|50%|75%|100%)', $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom'], $match )  &&
+                            count($match) > 0 )
+                        {
+                            $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom'] = $match[0];
+                        } else {
+                            $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom'] = '0%';
+                        }
                     }
                     if( isset($v['rex_effect_focuspoint_resize'] ) )
                     {


### PR DESCRIPTION
Update hat den Zoom-Faktor des Effektes Fokuspoint_fit nicht korrekt umgestellt und lieferte stets 0%. Behoben. Außerdem ein paar entdeckte Schreibfehler der Doku korrigiert.