### PR TITLE
neue Methode `focuspoint_media->hasFocus'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
     auch den Fall, dass das Bild nicht aus dem Medienpol kommt, sondern per 'effect_mediapath' aus
     einem anderen Verzeichnis. Als Koordinaten werden url (xy=..), Effektkonfiguration (Fallback) und
     der allgemeine Fallback "Bildmitte" herangezogen.
-
+- die Klasse `focuspoint_media` hat eine zusätzliche Methode `hasFocus`bekommen,
+  mit der abgeprüft wird, ob das Fokuspunkt-Metafeld gesetzt ist. 
 
 ## **08.09.2018 Version 2.0.2**
 

--- a/docs/de_de/main_intro.md
+++ b/docs/de_de/main_intro.md
@@ -1,13 +1,13 @@
 # Fokuspunkt: Einführung
 
 Die Mitte eines Bildes ist nicht oder nicht in jedem Fall auch der inhaltliche Mittelpunkt
-eines Bildes. Wird ein Bild in unterschiedlichen Formaten und Zusammenhängen eingesetzt,
+eines Bildes. Wird ein Bild in unterschiedlichen Formaten, Zuschnitten und Zusammenhängen eingesetzt,
 muss darauf geachtet werden, dass immer das Wesentliche bzw. Wichtigste zu sehen ist und
 nicht Nebensächlichkeiten.
 
 ![Beispiel](example.png)
 
-Beim automatischen Zuschnitt kann also viel schiefgehen.
+Beim automatischen Zuschnitt kann viel schiefgehen.
 
 Besser wäre es, man könnte einem Bild Informationen mitgeben, wo der inhaltliche Mittelpunkt - _der
 Fokuspunkt_ - des Bildes ist.
@@ -17,6 +17,9 @@ Das Fokuspoint-AddOn ist genau dafür entwickelt worden. Mit ihm können
 - für einzelne Medien interaktiv festgelegt werden, wo der Bildschwerpunkt ist,
 - Bilder unter Berücksichtigung des Fokuspunktes zugeschnitten werden,
 - unabhängig vom Format des Quellbildes Layout-sichere Zielformate erzeugt werden,
+
+Die [interaktive Festlegung](media_edit_interactive.md) der Fokuspunkte wird im Medienpool vorgenommen.
+Die Bildausgabe sollte über entsprechend konfigurierte [Bildtypen](mm_overview.md) des Media-Managers erfolgen.
 
 
 # Koordinaten
@@ -36,9 +39,12 @@ Metadatentyp `Focuspoint (AddOn)`.
 Die einfachste Variante der Eingabe ist die [interaktive Auswahl](media_edit_interactive.md) im Bild selbst. Man klickt einfach auf den
 gewünschten Fokuspunkt, der in das [Eingabefeld](media_edit_input.md) übertragen wird.
 
-# Nutzung
+# Bilder um den Fokuspunkt zentriert ausgeben
 
-Bilder werden z.B. über [Effekte](mm_overview.md) im Media-Manager Fokuspunkt-bezogen erzeugt.
+Bilder werden z.B. über [Typen im Media-Manager](mm_overview.md) Fokuspunkt-bezogen erzeugt. Wie das
+genau geht beschreibt die Dokumentation des Media-Managers. Es ist also kein spezifisches
+Ausgabemodul für Fokuspunkt-bezogene Bilder notwendig.
+
 
 
 > **Hinweis:**  

--- a/lib/focuspoint_media.php
+++ b/lib/focuspoint_media.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     2.0
+ *  @version     2.1
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -18,6 +18,7 @@
  *  @method __construct( )
  *  @method focuspoint_media get( string $name )
  *  @method array getFocus( string $metafield = null, array $default = null, $wh=false )
+ *  @method bool hasFocus( string $metafield = null )
  */
 
 class focuspoint_media extends rex_media
@@ -94,4 +95,24 @@ class focuspoint_media extends rex_media
         return $fp;
     }
 
+    /**
+     *  Ermittelt, ob ein Fokuspunkt gesetzt ist
+     *
+     *  Liefert true zurück, wenn
+     *  (1) das angegebene Fokuspunkt-Metafeld existiert und
+     *  (2) das Feld einen formal gültigen Wert liefert.
+     *
+     *  @param  string $metafield   Metafeld, aus dem die Koordinaten entnommen werden.
+     *                              default: med_focuspoint
+     *
+     *  @return bool   true, false
+     */
+    function hasFocus( $metafield = null )
+    {
+        // read the field
+        if(  $metafield == null ) $metafield = rex_effect_abstract_focuspoint::MED_DEFAULT;
+        $xy = (string) $this->getValue( (string)$metafield );
+        // check for a valid entry
+        return rex_effect_abstract_focuspoint::str2fp( $xy ) !== false;
+    }
 }


### PR DESCRIPTION
Während `getFocus`immer einen validen Fokuspunkt zum Bild liefert (auch dann wenn das Metafeld leer ist), gibt `hasFocus` Auskunft, ob überhaupt der Fokuspunkt gesetzt ist.  Die Dokumentation ist entsprechend erweitert.