### PR TITLE
V2.1: Diverse Optimierungen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## **01.12.2018 Version 'in Vorbereitung'**
+## **30.06.2019 Version 2.1**
 
-- Kleinere Schreibfehler korrgiert (danke @claudihey)
+- Kleinere Schreibfehler korrigiert (danke @claudihey)
 - In den Media-Manager-Effekten unterstützt die Koordinatenermittlung
     auch den Fall, dass das Bild nicht aus dem Medienpool kommt, sondern per 'effect_mediapath' aus
     einem anderen Verzeichnis. Als Koordinaten werden url (xy=..), Effektkonfiguration (Fallback) und
@@ -10,14 +10,19 @@
 - die Klasse `focuspoint_media` hat eine zusätzliche Methode `hasFocus` bekommen,
     mit der abgeprüft wird, ob das Fokuspunkt-Metafeld gesetzt ist (also eine gültige Koordinate enthält).
 - Im AddOn "Metainfo" wurde die Bearbeitung von Feldern, die den Metainfo-Datentyp "Focuspoint (AddOn)"
-    heben, beschränkt. Das Default-Feld "med_focuspoint" kann nicht gelöscht werden; Feldname und
+    haben, beschränkt. Das Default-Feld "med_focuspoint" kann nicht gelöscht werden; Feldname und
     Datentyp können nicht geändert werden.
-    Gleiches gilt für selbst angelegte Felder des Typs "Focuspoint (AddOn)", wenn sie in einem
-    Media-Manager-Effekt eingesetzt werden, der auf Focuspoint basiert.
-- Im AddOn "Media-Manager" ist Bearbeitung und Löschen des Typs "focuspoint_media_detail" gesperrt.
+    Gleiches gilt für selbst angelegte Metainfo-Felder des Typs "Focuspoint (AddOn)", sobald sie in einem
+    Media-Manager-Effekt eingesetzt werden, der auf der Klasse `rex_effect_abstract_focuspoint` basiert.
+- Im AddOn "Media-Manager" ist Bearbeiten und Löschen des Typs "focuspoint_media_detail" gesperrt.
+    (Hinweis von @tbaddade)
 - Die `boot.php` wurde entschlackt, um die Initialisierung der REDAXO-Instanz zu entlasten; die
-    entprechenden Codeböcke sind nach `focuspoint_boot.php` auelagert und werden nur bei Bedarf
+    entprechenden Codeböcke sind nach `focuspoint_boot.php` ausgelagert und werden nur bei Bedarf
     geladen.
+- Der Effekt 'focuspoint_resize' für den Media-Manager ist seit Release 2.0 auf "deprecated" gesetzt.
+    Wie angekündigt ist der Effekt ab Version 2.1 noch im Addon enthalten, er wird aber nicht mehr
+    in der `boot.php` aktiviert. (Siehe Dokumentation). Wer den Effekt noch benötigt, muss in
+    an anderer Stelle selbst aktivieren (`rex_media_manager::addEffect('rex_effect_focuspoint_resize');`).
 
 ## **08.09.2018 Version 2.0.2**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,20 @@
 
 - Kleinere Schreibfehler korrgiert (danke @claudihey)
 - In den Media-Manager-Effekten unterstützt die Koordinatenermittlung
-    auch den Fall, dass das Bild nicht aus dem Medienpol kommt, sondern per 'effect_mediapath' aus
+    auch den Fall, dass das Bild nicht aus dem Medienpool kommt, sondern per 'effect_mediapath' aus
     einem anderen Verzeichnis. Als Koordinaten werden url (xy=..), Effektkonfiguration (Fallback) und
     der allgemeine Fallback "Bildmitte" herangezogen.
-- die Klasse `focuspoint_media` hat eine zusätzliche Methode `hasFocus`bekommen,
-  mit der abgeprüft wird, ob das Fokuspunkt-Metafeld gesetzt ist. 
+- die Klasse `focuspoint_media` hat eine zusätzliche Methode `hasFocus` bekommen,
+    mit der abgeprüft wird, ob das Fokuspunkt-Metafeld gesetzt ist (also eine gültige Koordinate enthält).
+- Im AddOn "Metainfo" wurde die Bearbeitung von Feldern, die den Metainfo-Datentyp "Focuspoint (AddOn)"
+    heben, beschränkt. Das Default-Feld "med_focuspoint" kann nicht gelöscht werden; Feldname und
+    Datentyp können nicht geändert werden.
+    Gleiches gilt für selbst angelegte Felder des Typs "Focuspoint (AddOn)", wenn sie in einem
+    Media-Manager-Effekt eingesetzt werden, der auf Focuspoint basiert.
+- Im AddOn "Media-Manager" ist Bearbeitung und Löschen des Typs "focuspoint_media_detail" gesperrt.
+- Die `boot.php` wurde entschlackt, um die Initialisierung der REDAXO-Instanz zu entlasten; die
+    entprechenden Codeböcke sind nach `focuspoint_boot.php` auelagert und werden nur bei Bedarf
+    geladen.
 
 ## **08.09.2018 Version 2.0.2**
 

--- a/boot.php
+++ b/boot.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     2.0
+ *  @version     2.1
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -11,7 +11,8 @@
  *
  *  ------------------------------------------------------------------------------------------------
  *
- *
+ *  Teile der Verarbeitung sind - bis auf die Abfragen - ausgelagert, um die Code-Übersetzung
+ *  nur durchzuführen, wenn es notwendig ist, jedoch nicht bei jedem Aufruf.
  */
 
 if (rex::isBackend())
@@ -21,47 +22,33 @@ if (rex::isBackend())
     {
         case 'mediapool/media':
             // provide support for media detail-page
-            rex_view::addCssFile($this->getAssetsUrl('focuspoint.min.css'));
-            rex_view::addJsFile($this->getAssetsUrl('focuspoint.min.js'));
-            rex_extension::register('MEDIA_DETAIL_SIDEBAR', 'focuspoint::show_sidebar');
-            rex_extension::register('METAINFO_CUSTOM_FIELD', 'focuspoint::customfield' );
+            focuspoint_boot::mediaDetailPage( $this );
             break;
 
         case 'metainfo/articles':
         case 'metainfo/categories':
         case 'metainfo/clangs':
             // delete focuspoint-datatype from html-select for articles/categories/clangs
-            if( ($func = rex_request('func', 'string')) && $func != 'delete' )
-            {
-                rex_extension::register( 'METAINFO_TYPE_FIELDS', function( rex_extension_point $ep ){
-                    echo '<script>$(document).ready(function(){ $("select[name$=\'[type_id]\'] option:contains(\''.rex_effect_abstract_focuspoint::META_FIELD_TYPE.'\')").detach();});</script>';
-                });
-            }
+            focuspoint_boot::metainfoDefault();
             break;
 
         case 'metainfo/media':
+        dump($this);
             // prevent deletion of meta-fields still in use by effects
-            if( rex_request('func', 'string') == 'delete' )
-            {
-                rex_extension::register( 'PACKAGES_INCLUDED', function( rex_extension_point $ep ){
-                    if( $result = focuspoint::metafield_is_in_use( rex_request('field_id', 'int', 0) ) )
-                    {
-                        $_REQUEST['func'] = '';
-                        rex_extension::register('PAGE_TITLE_SHOWN', function(rex_extension_point $ep) use ($result) {
-                            $ep->setSubject(rex_view::error($result) . $ep->getSubject());
-                        });
-                    }
-                });
-            }
+            // limit changing the default-focuspoint-metafield: fieldname, fieldtype, no delete
+            // don´t remove the default-Metafield
+            focuspoint_boot::metainfoMedia();
+            break;
+
+        case 'media_manager/types':
+            // prevent deletion and editing of mediamanager-type used by focuspoint
+            focuspoint_boot::media_managerTypes();
+            break;
+
         case 'packages':
             // prevent deactivation if in use by effects
             // effective only in dialog-mode via AddOn-administration-page
-            if( rex_request('package', 'string') == $this->getName()
-                && isset($_REQUEST['rex-api-call'])
-                && $_REQUEST['rex-api-call'] == 'package' )
-            {
-                $_REQUEST['rex-api-call'] = 'focuspoint_package';
-            }
+            focuspoint_boot::packages( $this );
             break;
     }
 
@@ -69,4 +56,4 @@ if (rex::isBackend())
 
 rex_media_manager::addEffect('rex_effect_focuspoint_fit');
 // deprecated:
-rex_media_manager::addEffect('rex_effect_focuspoint_resize');
+// rex_media_manager::addEffect('rex_effect_focuspoint_resize');

--- a/boot.php
+++ b/boot.php
@@ -33,7 +33,6 @@ if (rex::isBackend())
             break;
 
         case 'metainfo/media':
-        dump($this);
             // prevent deletion of meta-fields still in use by effects
             // limit changing the default-focuspoint-metafield: fieldname, fieldtype, no delete
             // don´t remove the default-Metafield

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -1,7 +1,7 @@
 #   This file is part of the REDAXO-AddOn "focuspoint".
 #
 #   @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
-#   @version     2.0
+#   @version     2.1
 #   @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
 #
 #   For the full copyright and license information, please view the LICENSE
@@ -38,6 +38,9 @@ focuspoint_edit_label_meta = Basisfeld (med_...)
 focuspoint_edit_label_focus = Koordinate / Ersatzwert
 focuspoint_edit_label_width = Zielgröße: Breite
 focuspoint_edit_label_heigth = Zielgröße: Höhe
+focuspoint_edit_msg_inuse1 = Metafeld "{0}" ist in einem oder mehreren Media-Manager-Typen eingesetzt.
+focuspoint_edit_msg_inuse2 = Metafeld "{0}" ist in Systemfeld.
+focuspoint_edit_msg_inuse3 = "{0}" und "{1}" können nicht geändert werden; das Metafeld kann nicht gelöscht werden.
 # - focuspoint_resize
 focuspoint_edit_notice_widthheigth_resize = Angabe in Pixel
 focuspoint_edit_label_style = Modus

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -1,7 +1,7 @@
 #   This file is part of the REDAXO-AddOn "focuspoint".
 #
 #   @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
-#   @version     2.0
+#   @version     2.1
 #   @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
 #
 #   For the full copyright and license information, please view the LICENSE
@@ -38,6 +38,9 @@ focuspoint_edit_label_meta = Source (med_...)
 focuspoint_edit_label_focus = Coordinate / Fallback
 focuspoint_edit_label_width = Targetsize: Width
 focuspoint_edit_label_heigth = Targetsize: Height
+focuspoint_edit_msg_inuse1 = Metafeld "{0}" is in use by at leat one MediaManager-Type.
+focuspoint_edit_msg_inuse2 = Metafeld "{0}" reserved by focuspoint as default metafield.
+focuspoint_edit_msg_inuse3 = "Editing of {0}" und "{1}" is blocked; deleting the metafield is not possible.
 # - focuspoint_resize
 focuspoint_edit_notice_widthheigth_resize = Value as pixel
 focuspoint_edit_label_style = Mode

--- a/lang/es_es.lang
+++ b/lang/es_es.lang
@@ -1,7 +1,7 @@
 #   This file is part of the REDAXO-AddOn "focuspoint".
 #
 #   @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
-#   @version     2.0
+#   @version     2.1
 #   @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
 #
 #   For the full copyright and license information, please view the LICENSE

--- a/lang/sv_se.lang
+++ b/lang/sv_se.lang
@@ -1,7 +1,7 @@
 #   This file is part of the REDAXO-AddOn "focuspoint".
 #
 #   @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
-#   @version     2.0
+#   @version     2.1
 #   @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
 #
 #   For the full copyright and license information, please view the LICENSE

--- a/lib/focuspoint_boot.php
+++ b/lib/focuspoint_boot.php
@@ -97,7 +97,6 @@
                         $message .= '<u><b>'.rex_i18n::msg('focuspoint_doc').'</b></u><br>'.rex_i18n::msg('focuspoint_edit_msg_inuse2',$fpField).'<br>';
                     } elseif ( $effects=focuspoint::getFocuspointMetafieldInUse( $fpField ) ) {
                         $message .= '<u><b>'.rex_i18n::msg('focuspoint_doc').'</b></u><br>'.rex_i18n::msg('focuspoint_edit_msg_inuse1',$fpField).'<ul>';
-                        dump($effects);
                         foreach( $effects as $v ) {
                             $message .= '<li><a href="'
                                      . rex_url::backendController

--- a/lib/focuspoint_boot.php
+++ b/lib/focuspoint_boot.php
@@ -82,7 +82,6 @@
                     });
                 }
             });
-            return;
         }
         // limit changing the default-focuspoint-metafield: fieldname, fieldtype, no delete
         if( rex_request('func', 'string') == 'edit' )
@@ -126,7 +125,6 @@
                     }
                 }
             });
-            return;
         }
         // don´t remove the default-Metafield from the list
         rex_extension::register( 'REX_LIST_GET', function( rex_extension_point $ep ){

--- a/lib/focuspoint_boot.php
+++ b/lib/focuspoint_boot.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ *  This file is part of the REDAXO-AddOn "focuspoint".
+ *
+ *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
+ *  @version     2.1
+ *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  ------------------------------------------------------------------------------------------------
+ *
+ *  In der boot.php wird überprüft, ob eine Backend-Seite aufgerufen wird, innerhalb derer
+ *  besondetr Einstellungen z.B. mittels Extension-Points vorzunehmen sind.
+ *  Die Aktivitäten wurden in eine separate Datei ausgelagert, um für den Normalbetrieb der
+ *  REDAXO-Instanz eine schlanke boot.php mit geringen Kompilieraufwand zu haben.
+ *
+ *
+ *  @method void function mediaDetailPage( rex_addon $fpAddon )
+ *  @method void function metainfoDefault()
+ *  @method void function metainfoMedia()
+ *  @method void function media_managerTypes()
+ *  @method void function packages( rex_addon $fpAddon )
+ */
+
+ class focuspoint_boot {
+
+    /**
+     *  page=mediapool/media
+     *
+     *  Ressourcen für die Fokuspunkt-Erfassung im Mediapool einbinden
+     */
+    static public function mediaDetailPage( $fpAddon )
+    {
+        rex_view::addCssFile($fpAddon->getAssetsUrl('focuspoint.min.css'));
+        rex_view::addJsFile($fpAddon->getAssetsUrl('focuspoint.min.js'));
+        rex_extension::register('MEDIA_DETAIL_SIDEBAR', 'focuspoint::show_sidebar');
+        rex_extension::register('METAINFO_CUSTOM_FIELD', 'focuspoint::customfield' );
+    }
+
+    /**
+     *  page=metainfo/articles
+     *  page=metainfo/categories
+     *  page=metainfo/clangs
+     *
+     *  Auswahl des Metainfo-Datentyp "focuspoint (AddOn)" ausblenden da nur für Medien relevant
+     */
+    static public function metainfoDefault()
+    {
+        if( rex_request('func', 'string') != 'delete' )
+        {
+            rex_extension::register( 'METAINFO_TYPE_FIELDS', function( rex_extension_point $ep ){
+                echo '<script type="text/javascript">$(document).ready(function(){ $("select[name$=\'[type_id]\'] option:contains(\'',rex_effect_abstract_focuspoint::META_FIELD_TYPE,'\')").detach();});</script>';
+            });
+        }
+    }
+
+    /**
+     *  page=metainfo/media
+     *
+     *  1) Metafelder werden in Media-Manager-Typen bzw. den eingebundenen Focuspunkt-Effekten
+     *     referenziert. Sofern noch Effekte ein Focuspunkt-Metafeld nutzen, darf es nicht
+     *     gelöscht werden. Überprüfung beim Löschen.
+     *  2) Edit: Das Default-Metafeld für Fokuspunkte darf weder gelöscht werden noch darf es einen
+     *     anderen Namen oder Datentyp erhalten. In der Eingabemaske (func=edit) werden die
+     *     entsprechenden Felder gesperrt, gelöscht oder begrenzt. (per JS)
+     *     Gilt auch für Fokuspunkt-Felder, die bereits in Effekten/Typen des MM genutzt werden.
+     *  3) Liste: In der Liste der Metafelder wird ebenfalls das Default-Feld gegen Löschen gesperrt
+     */
+    static public function metainfoMedia()
+    {
+        // prevent deletion of meta-fields still in use by effects
+        if( rex_request('func', 'string') == 'delete' )
+        {
+            rex_extension::register( 'PACKAGES_INCLUDED', function( rex_extension_point $ep ){
+                if( $result = focuspoint::metafield_is_in_use( rex_request('field_id', 'int', 0) ) )
+                {
+                    $_REQUEST['func'] = '';
+                    rex_extension::register('PAGE_TITLE_SHOWN', function(rex_extension_point $ep) use ($result) {
+                        $ep->setSubject(rex_view::error($result) . $ep->getSubject());
+                    });
+                }
+            });
+            return;
+        }
+        // limit changing the default-focuspoint-metafield: fieldname, fieldtype, no delete
+        if( rex_request('func', 'string') == 'edit' )
+        {
+            rex_extension::register( 'REX_FORM_GET', function( rex_extension_point $ep ){
+                $form = $ep->getSubject();
+                $fpMetafields = focuspoint::getMetafieldList( );
+                $field_id = rex_request('field_id', 'int');
+                if( array_key_exists( $field_id, $fpMetafields ) ) {
+                    $fpField = $fpMetafields[ $field_id ];
+                    $message = '';
+                    if( $fpField == rex_effect_abstract_focuspoint::MED_DEFAULT ) {
+                        $message .= '<u><b>'.rex_i18n::msg('focuspoint_doc').'</b></u><br>'.rex_i18n::msg('focuspoint_edit_msg_inuse2',$fpField).'<br>';
+                    } elseif ( $effects=focuspoint::getFocuspointMetafieldInUse( $fpField ) ) {
+                        $message .= '<u><b>'.rex_i18n::msg('focuspoint_doc').'</b></u><br>'.rex_i18n::msg('focuspoint_edit_msg_inuse1',$fpField).'<ul>';
+                        dump($effects);
+                        foreach( $effects as $v ) {
+                            $message .= '<li><a href="'
+                                     . rex_url::backendController
+                                             ([
+                                                'page' => 'media_manager/types',
+                                                'type_id' => $v['type_id'],
+                                                'effects' => 1,
+                                             ])
+                                     . '">'.$v['name'].'</a></li>';
+                        }
+                        $message .= '</ul>';
+                    }
+                    if( $message ) {
+                        $message .= rex_i18n::msg('focuspoint_edit_msg_inuse3',rex_i18n::msg('minfo_field_label_name'),rex_i18n::msg('minfo_field_label_type'));
+                        $message = $form->getMessage() . "\n" . $message;
+                        $l = strlen( rex_request($form->getName() . '_msg', 'string') );
+                        if( $l ) $message = substr( $message, $l + 1 );
+                        $form->setMessage( $message );
+                        $id = rex_string::normalize(rex_i18n::msg('minfo_field_fieldset'),'-');
+                        echo '<script type="text/javascript">$(document).ready(function(){',
+                             '$(\'#rex-metainfo-field-',$id,'-name\').prop( "disabled", true );',
+                             '$(\'#rex-metainfo-field-',$id,'-delete\').remove();',
+                             '$(\'#rex-metainfo-field-',$id,'-type-id option:not([selected])\').hide().remove();',
+                             '});</script>';
+                    }
+                }
+            });
+            return;
+        }
+        // don´t remove the default-Metafield from the list
+        rex_extension::register( 'REX_LIST_GET', function( rex_extension_point $ep ){
+            $list = $ep->getSubject();
+            $list->setColumnFormat('delete', 'custom', function ($params) {
+                $list = $params['list'];
+                if( $list->getValue('name') == rex_effect_abstract_focuspoint::MED_DEFAULT ) {
+                    return '<small class="text-muted">' . rex_i18n::msg('focuspoint_doc') . '</small>';
+                }
+                if( $presetValue = $params['params'][0] ) return $list->formatValue('', $presetValue, false, 'delete');
+                return $list->getColumnLink('delete', $list->getValue('delete'));
+            }, [$list->getColumnFormat('delete')]);
+        });
+    }
+
+    /**
+     *  page=media_manager/types
+     *
+     *  Verhindert in der Liste der verfügbaren Media-Manager-typen, dass der von Focuspoint selbst
+     *  benötigte Media-Manager-Typ "focuspoint" gelöscht oder verändert wird.
+     *  Falls es sich nicht um die Zeile für "focuspoint" handelt, wird der ursprünglich
+     *  vorgesehene Zellinhalt ausgegeben.
+     */
+    static public function media_managerTypes()
+    {
+        if( rex_request('effects', 'int') != 1 ) {
+            rex_extension::register( 'REX_LIST_GET', function( rex_extension_point $ep ){
+
+                $function = function ($params) {
+                    $list = $params['list'];
+                    if( $list->getValue('name') == rex_effect_abstract_focuspoint::MM_TYPE ) {
+                        return '<small class="text-muted">' . rex_i18n::msg('focuspoint_doc') . '</small>';
+                    }
+                    $field = $params['field'];
+                    if( $presetValue = $params['params'][0] ) {
+                        return $list->formatValue($list->getValue($field), $presetValue, false, $field);
+                    }
+                    return $list->getColumnLink($field, $list->getValue($field));
+                };
+
+                $list = $ep->getSubject();
+                $list->setColumnFormat('deleteType', 'custom', $function, [$list->getColumnFormat('deleteType')]);
+                $list->setColumnFormat('editType', 'custom', $function, [$list->getColumnFormat('editType')]);
+                $label = rex_i18n::msg('media_manager_type_functions');
+                $list->setColumnFormat($label, 'custom', $function, [$list->getColumnFormat($label)]);
+            });
+        }
+    }
+
+    /**
+     *  page=packages
+     *
+     *  leitet auf einen spezialisierten API-Handler um.
+     */
+    static public function packages( $fpAddon )
+    {
+        if( rex_request('package', 'string') == $fpAddon->getName()
+            && isset($_REQUEST['rex-api-call'])
+            && $_REQUEST['rex-api-call'] == 'package' )
+        {
+            $_REQUEST['rex-api-call'] = 'focuspoint_package';
+        }
+    }
+
+}

--- a/lib/focuspoint_boot.php
+++ b/lib/focuspoint_boot.php
@@ -93,8 +93,10 @@
                 if( array_key_exists( $field_id, $fpMetafields ) ) {
                     $fpField = $fpMetafields[ $field_id ];
                     $message = '';
+                    $allCategories = '';
                     if( $fpField == rex_effect_abstract_focuspoint::MED_DEFAULT ) {
                         $message .= '<u><b>'.rex_i18n::msg('focuspoint_doc').'</b></u><br>'.rex_i18n::msg('focuspoint_edit_msg_inuse2',$fpField).'<br>';
+                        $allCategories = '$(\'#enable-restrictions-checkbox\').prop( "disabled", true );';            
                     } elseif ( $effects=focuspoint::getFocuspointMetafieldInUse( $fpField ) ) {
                         $message .= '<u><b>'.rex_i18n::msg('focuspoint_doc').'</b></u><br>'.rex_i18n::msg('focuspoint_edit_msg_inuse1',$fpField).'<ul>';
                         foreach( $effects as $v ) {
@@ -118,6 +120,7 @@
                         $id = rex_string::normalize(rex_i18n::msg('minfo_field_fieldset'),'-');
                         echo '<script type="text/javascript">$(document).ready(function(){',
                              '$(\'#rex-metainfo-field-',$id,'-name\').prop( "disabled", true );',
+                             $allCategories,
                              '$(\'#rex-metainfo-field-',$id,'-delete\').remove();',
                              '$(\'#rex-metainfo-field-',$id,'-type-id option:not([selected])\').hide().remove();',
                              '});</script>';

--- a/lib/focuspoint_boot.php
+++ b/lib/focuspoint_boot.php
@@ -95,21 +95,12 @@
                     $message = '';
                     $allCategories = '';
                     if( $fpField == rex_effect_abstract_focuspoint::MED_DEFAULT ) {
-                        $message .= '<u><b>'.rex_i18n::msg('focuspoint_doc').'</b></u><br>'.rex_i18n::msg('focuspoint_edit_msg_inuse2',$fpField).'<br>';
+                        $message = '<u><b>'.rex_i18n::msg('focuspoint_doc').'</b></u><br>'.rex_i18n::msg('focuspoint_edit_msg_inuse2',$fpField).'<br>';
                         $allCategories = '$(\'#enable-restrictions-checkbox\').prop( "disabled", true );';            
                     } elseif ( $effects=focuspoint::getFocuspointMetafieldInUse( $fpField ) ) {
-                        $message .= '<u><b>'.rex_i18n::msg('focuspoint_doc').'</b></u><br>'.rex_i18n::msg('focuspoint_edit_msg_inuse1',$fpField).'<ul>';
-                        foreach( $effects as $v ) {
-                            $message .= '<li><a href="'
-                                     . rex_url::backendController
-                                             ([
-                                                'page' => 'media_manager/types',
-                                                'type_id' => $v['type_id'],
-                                                'effects' => 1,
-                                             ])
-                                     . '">'.$v['name'].'</a></li>';
-                        }
-                        $message .= '</ul>';
+                         $message = '<u><b>'.rex_i18n::msg('focuspoint_doc').'</b></u><br>' .
+                            rex_i18n::msg('focuspoint_edit_msg_inuse1', $fpField) .
+                            '<br>' . focuspoint::getFocuspointEffectsInUseMessage( $effects );
                     }
                     if( $message ) {
                         $message .= rex_i18n::msg('focuspoint_edit_msg_inuse3',rex_i18n::msg('minfo_field_label_name'),rex_i18n::msg('minfo_field_label_type'));

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package:  focuspoint
-version:  '2.0.2'
+version:  '2.1.0'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/focuspoint
 


### PR DESCRIPTION
- Kleinere Schreibfehler korrigiert (danke @claudihey)
- In den Media-Manager-Effekten unterstützt die Koordinatenermittlung auch den Fall, dass das Bild nicht aus dem Medienpool kommt, sondern per 'effect_mediapath' aus einem anderen Verzeichnis. Als Koordinaten werden url (xy=..), Effektkonfiguration (Fallback) und der allgemeine Fallback "Bildmitte" herangezogen.
- die Klasse `focuspoint_media` hat eine zusätzliche Methode `hasFocus` bekommen, mit der abgeprüft wird, ob das Fokuspunkt-Metafeld gesetzt ist (also eine gültige Koordinate enthält).
- Im AddOn "Metainfo" wurde die Bearbeitung von Feldern, die den Metainfo-Datentyp "Focuspoint (AddOn)" haben, beschränkt. Das Default-Feld "med_focuspoint" kann nicht gelöscht werden; Feldname und Datentyp können nicht geändert werden.
Gleiches gilt für selbst angelegte Metainfo-Felder des Typs "Focuspoint (AddOn)", sobald sie in einem Media-Manager-Effekt eingesetzt werden, der auf der Klasse `rex_effect_abstract_focuspoint` basiert.
- Im AddOn "Media-Manager" ist Bearbeiten und Löschen des Typs "focuspoint_media_detail" gesperrt. (Hinweis von @tbaddade)
- Die `boot.php` wurde entschlackt, um die Initialisierung der REDAXO-Instanz zu entlasten; die entprechenden Codeböcke sind nach `focuspoint_boot.php` ausgelagert und werden nur bei Bedarf geladen.
- Der Effekt 'focuspoint_resize' für den Media-Manager ist seit Release 2.0 auf "deprecated" gesetzt.
Wie angekündigt ist der Effekt ab Version 2.1 noch im Addon enthalten, er wird aber nicht mehr
in der `boot.php` aktiviert. (Siehe Dokumentation). Wer den Effekt noch benötigt, muss in
an anderer Stelle selbst aktivieren: `rex_media_manager::addEffect('rex_effect_focuspoint_resize');`.