### PR TITLE
Rewritten: Preventing side-effects in MetaInfo and MediaManager

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -1,7 +1,7 @@
 #   This file is part of the REDAXO-AddOn "focuspoint".
 #
 #   @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
-#   @version     2.1
+#   @version     2.2
 #   @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
 #
 #   For the full copyright and license information, please view the LICENSE
@@ -39,9 +39,9 @@ focuspoint_edit_label_focus = Koordinate / Ersatzwert
 focuspoint_edit_label_width = Zielgröße: Breite
 focuspoint_edit_label_heigth = Zielgröße: Höhe
 focuspoint_edit_msg_inuse1 = Metafeld "{0}" ist in einem oder mehreren Media-Manager-Typen eingesetzt.
-focuspoint_edit_msg_inuse2 = Metafeld "{0}" ist in Systemfeld.
+focuspoint_edit_msg_inuse2 = Metafeld "{0}" ist ein Systemfeld.
 focuspoint_edit_msg_inuse3 = "{0}" und "{1}" können nicht geändert werden; das Metafeld kann nicht gelöscht werden.
-# - focuspoint_resize
+# - focuspoint_resize (deprecated since 2.0)
 focuspoint_edit_notice_widthheigth_resize = Angabe in Pixel
 focuspoint_edit_label_style = Modus
 focuspoint_edit_label_allow_enlarge = Wenn Bild zu klein

--- a/lib/focuspoint_reflection.php
+++ b/lib/focuspoint_reflection.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ *  This file is part of the REDAXO-AddOn "focuspoint".
+ *
+ *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
+ *  @version     2.2.0
+ *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  ------------------------------------------------------------------------------------------------
+ *
+ *  focuspoint_reflection ist eine erweiterte PHP ReflectionClass. Sie erlaubt auf etwas
+ *  vereinfachte Art Properties abzufragen oder zu ändern bzw. Methoden auszuführen, die
+ *  in der Klasse ansonsten nicht zugänglich sind (private oder protected)
+ *
+ *  HANDLE WITH CARE!
+ *
+ *  @method void function executeMethod ($method, array $params)
+ *  @method void function getPropertyValue ( $prop )
+ *  @method void function setPropertyValue ( $prop, $value )
+ */
+
+class focuspoint_reflection extends ReflectionClass {
+
+    public $obj = null;
+
+    function __construct( $obj ) {
+        parent::__construct( $obj );
+        $this->obj = $obj;
+    }
+
+    function executeMethod ($method, array $params){
+        $method = $this->getMethod( $method );
+        $method->setAccessible(true);
+        return $method->invokeArgs($this->obj, $params);
+    }
+
+    function getPropertyValue ( $prop ) {
+        $property = $this->getProperty($prop);
+        $property->setAccessible(true);
+        return $property->getValue( $this->obj );
+    }
+
+    function setPropertyValue ( $prop, $value ) {
+        $property = $this->getProperty($prop);
+        $property->setAccessible(true);
+        $property->setValue( $this->obj, $value );
+    }
+}


### PR DESCRIPTION
Wenn ein Meta-Info-Feld vom Typ "focuspoint (AddOn)" in einem Media-Manager-Effekt eingesetzt ist oder wenn es sich um das Default-Feld "med_focuspoint" handelt, darf es weder gelöscht noch umbenannt noch einen anderen Typ bekommen. Sonst geht der Media-Manager auf die Bretter. Das bisherige Verfahren, die Eingabefelder per eingeschleustem JS zu umzubauen, war wohl nicht Fehlerfrei, jedenfalls ließen sich zulässige feldänderungen (z.B. Reihenfolge) nicht abspeichern. 

Lösung war, nicht erst per JS auf dem Endgerät Formulare einzugreifen, sondern schon auf dem Server, indem das jeweilige Formular gezielt angepaßt wird.