### PR TITLE
Neue Version 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## **xx.xx.xxxx Version 2.x.0**
+## **28.03.2020 Version 3.0.0**
 
-Documentation reworked for proper dual-use on Github and in the REDAXO backend.
-HELP.PHP is rewritten accordingly. Supporting css/js added (help.min.xxx).
-(https://github.com/christophboecker/help.php)
+- Documentation reworked for proper dual-use on Github and in the REDAXO backend.
+  HELP.PHP is rewritten accordingly. Supporting css/js added (help.min.xxx).
+- Media-manager-effect "focuspoint_resize", deprecated since 30.08.2018 (2.0.0), is finally removed.
+  Save the file `lib/focuspoint_resize.php` to a save location bevor updating to 3.0.0 if you need the effect
+- Editing the addon-internal media-manager-type `focuspoint_media_detail` is partly enabled. Deletion and renaming is still prohibited.
 
 ## **09.03.2020 Version 2.2.2**
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Schreibt doch bitte auftretende Fehler, Notices und Wünsche als Issue auf [Gith
 
 ___
 
-Das Changelog findet sich hier: [CHANGELOG.md](docs/CHANGELOG.md)
+Das Changelog findet sich hier: [CHANGELOG.md](CHANGELOG.md)
 
 ---
 

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package:  focuspoint
-version:  '2.2.2'
+version:  '3.0.0'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/focuspoint
 


### PR DESCRIPTION
- Dokumentation so umgebaut, dass sie auf Github und im Backend ähnlich dargestellt wird (Dual-Use)
  HELP.PHP ist dafür komplett neu geschrieben; zusätzlich sind unterstützende css/js dabei (help.min.xxx) z.B. für Syntax-Highlighting
- Media-manager-effect "focuspoint_resize", ohnehin seit 30.08.2018 (2.0.0) als deprecated markiert, ist jetzt komplett raus.
  Wer ihn noch benötigt kopiere die Datei `lib/focuspoint_resize.php` vor dem Update in ein sicheres Verzeichnis, z.B. nach project/lib.
- Der intern genutze Media-Manager-Effekt `focuspoint_media_detail` kann nun begrenzt geändert werden. Löschen und Ändern des Namens ist weiterhin nicht zulässig.
