### PR TITLE
Anpassung an PHP8-Umgang mit Auto-Committ der Datenbank (DDL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## **01.03.2021 Version 3.0.2**
+
+- Bugfix: PHP8 fixed an error in MySQL transaction handling regarding DDL-statements, with now can
+  results  properly in an exception during installation. The new installation routine works without
+  transactions.
+- A successfull installation now provides detailed information (available since REDAXO 5.12).
+
 ## **09.12.2020 Version 3.0.1**
 
 - PHP version-dependency in package.yml changed to enable installation with PHP 8 as well as PHP 7
@@ -10,7 +17,8 @@
   HELP.PHP is rewritten accordingly. Supporting css/js added (help.min.xxx).
 - Media-manager-effect "focuspoint_resize", deprecated since 30.08.2018 (2.0.0), is finally removed.
   Save the file `lib/focuspoint_resize.php` to a save location bevor updating to 3.0.0 if you need the effect
-- Editing the addon-internal media-manager-type `focuspoint_media_detail` is partly enabled. Deletion and renaming is still prohibited.
+- Editing the addon-internal media-manager-type `focuspoint_media_detail` is partly enabled.
+  Deletion and renaming is still prohibited.
 
 ## **09.03.2020 Version 2.2.2**
 
@@ -54,7 +62,8 @@ Bugfixes:
 ## **22.08.2019 Version 2.1.1**
 
 - Maintenance-version, no functional changes
-- Injection of focuspoint-help into Media-Manager is changed in REX 5.8.0 with respect to the new way, the Media-Manager-help (overview) is provided
+- Injection of focuspoint-help into Media-Manager is changed in REX 5.8.0 with respect to the new
+  way, the Media-Manager-help (overview) is provided
 - Requirements-section in package.yml changed to reflect REX 5.8.0
 - Traducción en castellano - thanks to @nandes2062
 

--- a/install.php
+++ b/install.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     2.0
+ *  @version     3.0.2
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -24,77 +24,184 @@
 // make addon-parameters available
 include_once ( 'lib/effect_focuspoint.php' );
 
-$sql = rex_sql::factory();
-$sql->beginTransaction();
+$successMsg = [];
 $message = '';
+$sql = rex_sql::factory();
 
-// Add or identify meta_type for focuspoint-fields
-$qry = 'SELECT id FROM ' . rex::getTable('metainfo_type') . ' WHERE label=:label LIMIT 1';
-$type_id = $sql->getArray($qry, [':label' => rex_effect_abstract_focuspoint::META_FIELD_TYPE]);
+// Erst einmal prüfen, welche Elemente bereits existieren und ob die Daten stimmig sind.
+// Daraus Aktionsanforderungen ableiten statt sofort fehlende Elemente anzulegen.
+// Grund: das in den SQL-Statements auch DDL-Befehle (ALTER TABLE) vorkommen können, funktionierten
+// die SQL-Transaktionen bzw. Committ/rollBack nicht über die gesamte Installation.
+// (Ist eine Art Workaround)
 
-$type_id = $type_id
-        ? (int)$type_id[0]['id']
-        : rex_metainfo_add_field_type(rex_effect_abstract_focuspoint::META_FIELD_TYPE, 'varchar', 20);
+$db_metafield = rex::getTable('metainfo_field');
+$db_metatype = rex::getTable('metainfo_type');
+$db_mmtype = rex::getTable('media_manager_type');
+$db_mmeffect = rex::getTable('media_manager_type_effect');
+$db_media = rex::getTable('media');
 
-// if valid type_id add default-field
-if( is_numeric($type_id) )
-{
-    // Identify yet existing metafield by name and read current type_id
-    $qry = 'SELECT type_id FROM ' . rex::getTable('metainfo_field') . ' WHERE name=:name LIMIT 1';
-    $field = $sql->getArray($qry, [':name' => rex_effect_abstract_focuspoint::MED_DEFAULT]);
+$meta_action_type = false;
+$meta_action_field = false;
+$meta_action_media = false;
+$meta_action_connect = false;
 
-    if( $field )
-    {
-        if( $field[0]['type_id'] != $type_id )
-        {
-            $message = rex_i18n::msg( 'focuspoint_install_field_exists', rex_effect_abstract_focuspoint::MED_DEFAULT,rex_effect_abstract_focuspoint::META_FIELD_TYPE );
-        }
-    }
-    else
-    {
-        // field does not exist. Add field
-        $result = rex_metainfo_add_field('translate:focuspoint_field_label', rex_effect_abstract_focuspoint::MED_DEFAULT, '', '', $type_id, '', '', '', '');
-        if( $result !== true )
-        {
-            $message = rex_i18n::msg( 'focuspoint_install_field_error', rex_effect_abstract_focuspoint::MED_DEFAULT, "<strong><i>$result</i></strong>" );
-        }
-    }
+$mm_action_type = false;
+$mm_action_effect = false;
 
-    // add media-manager-type for interactiv focuspoint-selection
-    // don't check existance of effect "resize"; just setup.
-    $sql->setQuery('select id, name from '.rex::getTable('media_manager_type').' where name="'.rex_effect_abstract_focuspoint::MM_TYPE.'" LIMIT 1');
-    if( $sql->getRows() ) {
-        $id = $sql->getValue('id');
+// --- Metainfos analysieren -----------------------------------------------------------------------
+
+$qry = 'SELECT a.id,a.type_id,b.id AS tid,b.label AS tlabel FROM '.$db_metafield.' AS a LEFT JOIN '.$db_metatype.' AS b ON a.type_id=b.id WHERE a.name=:name';
+$meta_field = $sql->getArray( $qry, [':name' => rex_effect_abstract_focuspoint::MED_DEFAULT]);
+$meta_field_id = $meta_field ? $meta_field[0]['id'] : null;
+$meta_field_type = $meta_field ? $meta_field[0]['type_id'] : null;
+$meta_field_tid = $meta_field ? $meta_field[0]['tid'] : null;
+$meta_field_tlabel = $meta_field ? $meta_field[0]['tlabel'] : null;
+
+$qry = 'SELECT id FROM ' . $db_metatype . ' WHERE label=:label LIMIT 1';
+$meta_type = $sql->getArray( $qry, [':label' => rex_effect_abstract_focuspoint::META_FIELD_TYPE] );
+$meta_type_id = $meta_type ? $meta_type[0]['id'] : null;
+
+// Typ und Feld existieren. Die Typ-ID im Feld entspricht der Metatyp-Id
+if ( $meta_field_id && $meta_type_id && $meta_field_type === $meta_type_id ) {
+    // ok, alles passt zusammen
+}
+
+// Typ und Feld existieren. Die Typ-ID im Feld verweist auf einen anderen Typ
+elseif ( $meta_field_id && $meta_type_id && $meta_field_type === $meta_field_tid ) {
+    // Das Metafeld hat den falschen Typ. Abbruch und Aufforderung zum Aufräumen
+    // Abbruch
+    $message = '1 '.rex_i18n::msg( 'focuspoint_install_field_exists', rex_effect_abstract_focuspoint::MED_DEFAULT,rex_effect_abstract_focuspoint::META_FIELD_TYPE );
+}
+
+// Typ und Feld existieren. Die Typ-ID im Feld verweist auf einen nicht existenten Typ
+elseif ( $meta_field_id && $meta_type_id && !$meta_field_tid ) {
+    // Feld ändern auf meta_type_id
+    $meta_action_connect = true;
+}
+
+// nur Typ existiert
+elseif ( $meta_type_id && !$meta_field_tid ) {
+    // Feld auf den Typ anlegen
+    $meta_action_field = true;
+    $meta_action_connect = true;
+}
+
+// nur Feld existiert und verweist auf einen existenten Typ
+elseif ( $meta_field_id && $meta_field_tid ) {
+    // Das Metafeld hat den falschen Typ. Abbruch und Aufforderung zum Aufräumen
+    // Abbruch
+    $message = '2 '.rex_i18n::msg( 'focuspoint_install_field_exists', rex_effect_abstract_focuspoint::MED_DEFAULT,rex_effect_abstract_focuspoint::META_FIELD_TYPE );
+}
+
+// nur Feld existiert und verweist auf einen nicht existenten Typ
+elseif ( $meta_field_id ) {
+    // Typ anlegen und mit dem Feld verbinden
+    $meta_action_type = true;
+    $meta_action_connect = true;
+}
+
+// weder Feld noch Typ existieren
+else {
+    $meta_action_type = true;
+    $meta_action_field = true;
+    $meta_action_connect = true;
+}
+
+// Für das Metafeld besteht die Abhängigkeit zur zugehörigen Spalte in rex_media
+$sql->setQuery('SELECT * FROM '.$db_media.' LIMIT 1');
+$media_feld = in_array(rex_effect_abstract_focuspoint::MED_DEFAULT, $sql->getFieldnames());
+// Metafeld existiert in rex_metainfo_field, aber die Spalte in rex_media fehlt
+if ( !$meta_action_field && !$media_feld ) {
+    $meta_action_media = true;
+}
+// Metafeld existiert nicht in rex_metainfo_field, aber die Spalte in rex_media ist existent
+elseif ( $meta_action_field && $media_feld ){
+    // Da die Spalte wichtige Informationen enthalten könnte: Meldung und Abbruch
+    $message = rex_i18n::msg( 'focuspoint_install_media_exists', rex_effect_abstract_focuspoint::MED_DEFAULT,$db_media );
+}
+
+
+// --- Media-Manager-Einträge analysieren ----------------------------------------------------------
+
+$qry = 'SELECT a.id,b.type_id from '.$db_mmtype.' AS a LEFT JOIN '.$db_mmeffect.' AS b ON a.id = b.type_id WHERE a.name=:name LIMIT 1';
+$mm_type = $sql->getArray( $qry, [':name' => rex_effect_abstract_focuspoint::MM_TYPE]);
+$mm_action_type = null === ($mm_type[0]['id'] ?? null);
+$mm_action_effect = null === ($mm_type[0]['type_id'] ?? null);
+
+
+// --- Metainfos anlegen ---------------------------------------------------------------------------
+
+// Die fehlenden Elemente sind vorab ermittelt. Fehler z.B. durch doppelte Kennungen sollten also
+// nicht auftreten. Das Restrisiko einer unvollständigen Installation mit Restanten ist minimal.
+// Fehlende Elemente werden ergänzt
+
+if( $meta_action_type && !$message ) {
+    $result = rex_metainfo_add_field_type(rex_effect_abstract_focuspoint::META_FIELD_TYPE, 'varchar', 20);
+    if( is_numeric($result) ) {
+        $meta_type_id = $result;
+        $meta_action_connect = true;
+        $successMsg[] = rex_i18n::msg( 'focuspoint_install_type_ok', rex_effect_abstract_focuspoint::META_FIELD_TYPE );
     } else {
-        $sql->setTable( rex::getTable('media_manager_type') );
-        $sql->setValue( 'name', rex_effect_abstract_focuspoint::MM_TYPE );
-        $sql->insert();
-        $id = $sql->getLastId();
+        $message = rex_i18n::rawMsg( 'focuspoint_install_type_error', rex_effect_abstract_focuspoint::META_FIELD_TYPE, "<strong><i>$$result</i></strong>" );
     }
-    $sql->setTable( rex::getTable('media_manager_type_effect') );
-    $sql->setWhere( 'type_id='.$id );
-    $sql->delete();
-    $sql->setTable( rex::getTable('media_manager_type_effect') );
-    $sql->setValue( 'type_id', $id );
+}
+
+if( $meta_action_field && !$message ) {
+    $result = rex_metainfo_add_field('translate:focuspoint_field_label', rex_effect_abstract_focuspoint::MED_DEFAULT, '', '', $meta_type_id, '', '', '', '');
+    if( true === $result ) {
+        $successMsg[] = rex_i18n::msg( 'focuspoint_install_field_ok', rex_effect_abstract_focuspoint::MED_DEFAULT );
+        $meta_action_connect = false; // impliziet beim Anlegen durchgeführt
+        $meta_action_media = false; // impliziet beim Anlegen durchgeführt
+    } else {
+        $message = rex_i18n::rawMsg( 'focuspoint_install_field_error', rex_effect_abstract_focuspoint::MED_DEFAULT, "<strong><i>$result</i></strong>" );
+    }
+}
+
+if( $meta_action_media && !$message ) {
+    $tableManager = new rex_metainfo_table_manager('rex_media');
+    if ( $tableManager->addColumn(rex_effect_abstract_focuspoint::MED_DEFAULT, 'varchar', 20, '') ) {
+        $successMsg[] = rex_i18n::msg( 'focuspoint_install_media_ok', rex_effect_abstract_focuspoint::MED_DEFAULT, $db_media );
+    } else {
+        $message = rex_i18n::rawMsg( 'focuspoint_install_media_error', rex_effect_abstract_focuspoint::MED_DEFAULT, $db_media );
+    }
+}
+
+if( $meta_action_connect && !$message ) {
+    $sql->setTable( $db_metafield );
+    $sql->setValue( 'type_id', $meta_type_id );
+    $sql->setWhere( 'name=:name', [':name'=>rex_effect_abstract_focuspoint::MED_DEFAULT] );
+    $sql->update();
+    $successMsg[] = rex_i18n::msg( 'focuspoint_install_link_ok', rex_effect_abstract_focuspoint::META_FIELD_TYPE, rex_effect_abstract_focuspoint::MED_DEFAULT );
+}
+
+// --- Media-Manager-Einträge anlegen --------------------------------------------------------------
+
+if ( $mm_action_type && !$message ) {
+    $sql->setTable( $db_mmtype );
+    $sql->setValue( 'name', rex_effect_abstract_focuspoint::MM_TYPE );
+    $sql->addGlobalCreateFields();
+    $sql->addGlobalUpdateFields();
+    $sql->insert();
+    $mm_type_id = $sql->getLastId();
+    $mm_action_effect = true;
+    $successMsg[] = rex_i18n::msg( 'focuspoint_install_mmtype_ok', rex_effect_abstract_focuspoint::MM_TYPE );
+}
+
+if ( $mm_action_effect && !$message ) {
+    $sql->setTable( $db_mmeffect );
+    $sql->setValue( 'type_id', $mm_type_id );
     $sql->setValue( 'effect', 'resize' );
     $sql->setValue( 'parameters', '{"rex_effect_resize":{"rex_effect_resize_width":"1024","rex_effect_resize_height":"1024","rex_effect_resize_style":"maximum","rex_effect_resize_allow_enlarge":"enlarge"}}' );
     $sql->addGlobalUpdateFields();
     $sql->addGlobalCreateFields();
     $sql->insert();
-
-}
-// no valid type_id
-else
-{
-    $message = rex_i18n::msg( 'focuspoint_install_type_error', rex_effect_abstract_focuspoint::META_FIELD_TYPE, "<strong><i>$type_id</i></strong>" );
+    $successMsg[] = rex_i18n::msg( 'focuspoint_install_mmeffect_ok', rex_effect_abstract_focuspoint::MM_TYPE );
 }
 
-if( $message )
-{
-    $sql->rollBack();
+// Fehlermeldung übertragen; Abbruch
+if( $message ) {
     $this->setProperty('installmsg', $message );
+    return;
 }
-else
-{
-    $sql->commit();
-}
+
+$this->setProperty('successmsg', '<ul><li>'.implode('</li><li>',$successMsg).'</ul>' );

--- a/install.php
+++ b/install.php
@@ -204,4 +204,6 @@ if( $message ) {
     return;
 }
 
-$this->setProperty('successmsg', '<ul><li>'.implode('</li><li>',$successMsg).'</ul>' );
+if( $successMsg ) {
+    $this->setProperty('successmsg', '<ul><li>'.implode('</li><li>',$successMsg).'</ul>' );
+}

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -1,7 +1,7 @@
 #   This file is part of the REDAXO-AddOn "focuspoint".
 #
 #   @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
-#   @version     2.x.0
+#   @version     3.0.2
 #   @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
 #
 #   For the full copyright and license information, please view the LICENSE
@@ -15,6 +15,14 @@ focuspoint_doc = Fokuspunkt-AddOn
 focuspoint_install_field_exists = Das Feld "{0}" existiert, hat aber den falschen Feldtyp. Feldtyp ändern auf "{1}" oder Feld umbenennen/löschen.
 focuspoint_install_field_error = Fehler beim Anlegen des Metafeldes {0}: {1}
 focuspoint_install_type_error = Fehler beim Anlegen des Meta-Typs {0}: {1}
+focuspoint_install_media_exists = Spalte "{0}" in Tabelle "{1}" existiert bereits; Spalte umbenennen oder löschen
+focuspoint_install_field_ok = Metainfo-Feld "{0}" angelegt
+focuspoint_install_type_ok = Metainfo-Typ "{0}" angelegt
+focuspoint_install_media_ok = Fehlende Spalte "{0}" in Tabelle "{1}" ergänzt
+focuspoint_install_link_ok = Metainfo-Typ "{0}" und Metainfo-Feld "{1}" neu zugeordnet
+focuspoint_install_media_error = Fehler beim Anlegen der Spalte {0} in Tabelle {1}
+focuspoint_install_mmtype_ok = Media-Manager-Type "{0}" angelegt
+focuspoint_install_mmeffect_ok = Default-Effekte des Media-Manager-Type "{0}" eingetragen
 focuspoint_uninstall_metafields = Zusätzliche Metafelder des Typs "{0}". Das AddOn kann erst gelöscht werden, wenn die Felder gelöscht sind oder auf einen anderen Datentyp (text) umgestellt.
 focuspoint_uninstall_external_effects = Zusätzliche Fokuspunkt-Effekte. Das AddOn kann erst gelöscht werden, wenn die Effekte deaktiviert sind.
 focuspoint_uninstall_effects_in_use = Betroffene Media-Manager-Typen:

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -1,7 +1,7 @@
 #   This file is part of the REDAXO-AddOn "focuspoint".
 #
 #   @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
-#   @version     2.x.0
+#   @version     3.0.2
 #   @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
 #
 #   For the full copyright and license information, please view the LICENSE
@@ -15,6 +15,14 @@ focuspoint_doc = Focuspoint-AddOn
 focuspoint_install_field_exists = Field "{0}" already exists, but with wrong type. Change type to "{1}" or remove/rename field.
 focuspoint_install_field_error = Error creating meta-field  {0}: {1}
 focuspoint_install_type_error = Error creating meta-type {0}: {1}
+focuspoint_install_media_exists = Column "{0}" of table "{1}" already exists; rename or delete column
+focuspoint_install_field_ok = Metainfo-field "{0}" created
+focuspoint_install_type_ok = Metainfo-type "{0}" created
+focuspoint_install_media_ok = Missing column "{0}" in table "{1}" added
+focuspoint_install_link_ok = Metainfo-type "{0}" and metainfo-field "{1}" connection repaired
+focuspoint_install_media_error = Error creating column {0} of table {1}
+focuspoint_install_mmtype_ok = Media-Manager-Type "{0}" created
+focuspoint_install_mmeffect_ok = Default-Effects of Media-Manager-type "{0}" created
 focuspoint_uninstall_metafields = Additional meta-fields of type "{0}" found. First delete these fields or switch to another field-type ("text"), then try again to delete the Focuspoint-AddOn.
 focuspoint_uninstall_external_effects = Additional focuspoint-effects found. First deacticate these effects, then try again to delete the Focuspoint-AddOn..
 focuspoint_uninstall_effects_in_use = Affected Media-Manager-Types:

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package:  focuspoint
-version:  '3.0.1'
+version:  '3.0.2'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/focuspoint
 


### PR DESCRIPTION
In PHP8 wurde ein Bug im PDO korrigiert, der nun durch DDL-Statements verursachte automatische Committs in Transaktionen richtig weitermeldet. Die Änderung führt seit PHP8 in der Installation zu einer Exception. Die Installation ist nun umgeschrieben und versucht, potentelle Installationsprobleme durch eine vorgezogene Analysephase zu erkennen. 

Closes #104, siehe auch https://github.com/redaxo/redaxo/issues/4495