### PR TITLE
R5.13 mp hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## **17.10.2021 Version 4.0.0**
+
+- Changes in the mediapool markup forced an update in the hook mechanismen, which enables Focuspoint´s interactive selection in the mediapool-sidebar. Due the
+  changed mechanismen Focuspoint 4.0 and onward is incompatible with REDAXO 5.12.x and prior versions.
+
 ## **23.10.2021 Version 3.1.0**
 
 - Enhanced CSS for darkmode compatibility (thanks to @schuer); active with REDAXO 5.13.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## **17.10.2021 Version 4.0.0**
+## **17.11.2021 Version 4.0.0**
 
 - Changes in the mediapool markup forced an update in the hook mechanismen, which enables Focuspoint´s interactive selection in the mediapool-sidebar. Due the
   changed mechanismen Focuspoint 4.0 and onward is incompatible with REDAXO 5.12.x and prior versions.

--- a/lib/focuspoint.php
+++ b/lib/focuspoint.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     2.2.1
+ *  @version     4.0.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -66,7 +66,7 @@ class focuspoint
 
         // Identifiziere das Vorschaubild
         //
-        //      <a href="index.php?rex_media_type=rex_mediapool_maximized&amp;rex_media_file=filename&amp;buster=1527191505">
+        //      <a href="index.php?rex_media_type=rex_media_large&amp;rex_media_file=filename&amp;buster=1527191505">
         //          <img class="img-responsive" src="index.php?rex_media_type=rex_mediapool_detail&amp;rex_media_file=filename&amp;buster=1234567890" alt="0" title="0">
         //      </a>
         //
@@ -76,9 +76,9 @@ class focuspoint
         $text = $ep->getSubject();
         $mediafile = $params['filename'];
 
-        $referenz = '<a href="'.rex_media_manager::getUrl('rex_mediapool_maximized', urlencode($mediafile) );
-
+        $referenz = '<a href="'.rex_media_manager::getUrl('rex_media_large', urlencode($mediafile) );
         $p1 = stripos( $text, $referenz );
+
         if( $p1 === false ) return;
 
         $p2 = stripos( $text, '</a>', $p1 + strlen($referenz) );

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package:  focuspoint
-version:  '3.1.0'
+version:  '4.0.0'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/focuspoint
 
@@ -16,11 +16,11 @@ pages:
 
 requires:
     packages:
-        media_manager: '^2.7.0'
-        mediapool: '^2.6.0'
-    redaxo: '^5.8.0'
+        media_manager: '^2.12.0'
+        mediapool: '^2.11.0'
+    redaxo: '^5.13.0'
     php:
-        version: '>=7.1'
+        version: '>=7.3'
 
 help:
     # Default-View, für page=packages (Aufruf aus der Addon-Verwaltung)


### PR DESCRIPTION
Changes in the Mediapool markup forced an update in the hook mechanismen, which enables Focuspoint´s interactive selection in the Mediapool-sidebar. Due the changed mechanismen Focuspoint 4.0 and onward is incompatible with REDAXO 5.12.x and prior versions.