### PR TITLE
Code-Verbesserungen nach Analyse mit rexstan

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     3.0
+ *  @version     4.0.2
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -13,6 +13,8 @@
  *
  *  Teile der Verarbeitung sind - bis auf die Abfragen - ausgelagert, um die Code-Übersetzung
  *  nur durchzuführen, wenn es notwendig ist, jedoch nicht bei jedem Aufruf.
+ *
+ *  @var rex_addon $this
  */
 
 if (rex::isBackend())

--- a/help.php
+++ b/help.php
@@ -3,30 +3,56 @@
  *  HELP.PHP für REDAXO-Addons
  *
  *  @author     Christoph Böcker <https://github.com/christophboecker>
- *  @version    2.0
+ *  @version    2.4
  *  @copyright  Christoph Böcker <https://github.com/christophboecker>
  *  @license    MIT
  *  @see        https://github.com/christophboecker/help.php  Repository on Github
  *  @see        https://github.com/christophboecker/help.php/blob/master/manual.md  Manual/Documentation
  *
- *  für REDAXO ab V5.7
+ *  für REDAXO ab V5.10
  *
  *  @var rex_addon $this
  */
 
+
+/*
+    2.1: wirft _pjax aus dem Request; klemmt sonst womöglich
+    2.1: Zweistufige Menüs
+    2.1: Menüstrukturen (help:) optional in eigener help.yml statt package.yml
+*/
 if( !class_exists('help_documentation') )
 {
     class help_documentation {
 
+        /** @var array<mixed> */
         public $navigation = [];
+
+        /** @var string */
         public $initialPage = '';
+
+        /** @var string */
         public $activePage = '';
+
+        /** @var string */
         public $dir = '';
+
+        /** @var integer */
         public $dirLen = 0;
+
+        /** @var string */
         public $filename = '';
+
+        /** @var string */
         public $filetype = '';
+
+        /** @var string */
         public $targetfile = '';
+        
+        /** @var rex_addon|null */
         public $context = null;
+
+        /** @var array<mixed> */
+        public $prohibited = [];
 
         //  $filename       ist der Name der anzuzeigenden Datei im $dir. Sofern es keine anderen Angaben
         //                  gibt, wird die README.md des Addons angezeigt.
@@ -40,31 +66,77 @@ if( !class_exists('help_documentation') )
         //
         //  Oberste Priorität ist die Angabe in der URL (...&doc=...)
 
+        /**
+         *  @param rex_addon $addon
+         *  @return void
+         */
         function __construct( \rex_addon $addon )
         {
             $this->context = $addon;
+            $user = rex::getUser();
             //  Im weiteren Verlauf wird immer wieder das aktuelle Verzeichnis (Root des Addons) benötigt
             $this->dir = $addon->getPath();
             $this->dirLen = strlen( $this->dir );
 
-            $navigation = $addon->getProperty('help',[]);
-            $this->navigation = $navigation[rex_be_controller::getCurrentPage()] ?? $navigation['default'] ?? [];
+            $navigation = rex_file::getConfig( $addon->getPath('help.yml'), [] );
+            if( $navigation ):
+                array_walk_recursive($navigation, function(&$a,$b){
+                    if( 'translate:'==substr($a,0,10) ) $a = rex_i18n::translate($a);
+                });
+            else:
+                $navigation = $addon->getProperty('help',[]);
+            endif;
+
+            $this->navigation = $navigation[\rex_be_controller::getCurrentPage()] ?? $navigation['default'] ?? [];
+
+            // Berechtigungen prüfen und rauswerfen, was nicht berechtigt ist
+            // Aus der Navigation das Array 'permissions' extrahieren
+            $permissions = $this->navigation['permissions'] ?? [];
+            if( $permissions ) {
+                // aus der Navigation entfernen
+                unset( $this->navigation['permissions'] );
+                foreach( $permissions as $k=>$v ) {
+                    foreach( (array) $v as $perm ) {
+                        if( $perm && !$user->hasPerm($perm) ) {
+                            $this->prohibited[] = $k;
+                        }
+                    }
+                }
+            }
+
+            foreach( $this->navigation as $k1=>$v1 ) {
+                $permission = $v1['perm'] ?? '';
+                if( $permission && !$user->hasPerm($permission) ) {
+                    $this->prohibited[] = $v1['path'];
+                    unset( $this->navigation[$k1] );
+                }
+                foreach( ($v1['subnav'] ?? []) as $k2=>$v2 ) {
+                    $subPermission = $v2['perm'] ?? $permission;
+                    if( $subPermission && !$user->hasPerm($subPermission) ) {
+                        $this->prohibited[] = $v2['path'];
+                        unset( $this->navigation[$k1][$k2] );
+                    }
+                }
+            }
+            $this->prohibited = array_unique( $this->prohibited );
+
             if( isset($this->navigation['initial']) && $this->navigation['initial'] ){
                 $this->initialPage = $this->navigation['initial'];
                 unset( $this->navigation['initial'] );
             }
 
             foreach( $this->navigation as $k=>$v ) {
-                if( isset($v['path']) ){
+                if( isset($v['path']) ):
                     if( !$this->activePage ) $this->activePage = $v['path'];
-                    if( isset($v['active']) && true===$v['active'] ){
+                    if( isset($v['active']) && true===$v['active'] ):
                         $this->activePage = $v['path'];
                         break;
-                    }
-                }
+                    endif;
+                endif;
             }
-            $this->filename = rex_request( 'doc','string',$this->initialPage ?: $this->activePage ?: 'README.md' );
-            $this->filename =  mb_ereg_replace('\\\\|/', DIRECTORY_SEPARATOR, $this->filename, 'msr');
+            $this->filename = \rex_request( 'doc','string',$this->initialPage ?: $this->activePage ?: 'README.md' );
+            // Wenn das replace auf einen Fehler läuft, stimt wohl etwas Grundlegendws nicht. Abschalten.
+            $this->filename =  mb_ereg_replace('\\\\|/', DIRECTORY_SEPARATOR, $this->filename, 'msr') ?: '';
             $this->filetype = pathinfo( $this->filename,PATHINFO_EXTENSION );
 
             $this->targetfile = $this->getDocumentName( );
@@ -82,9 +154,13 @@ if( !class_exists('help_documentation') )
         //      «addon_root»/CREDITS.md
         //      «addon_root»/docs/*
         //
-        //  Als Nebeneffekt wird geprüft, ob die DAtei überhaupt exisitert bzw. ob sie in einer
+        //  Als Nebeneffekt wird geprüft, ob die Datei überhaupt exisitert bzw. ob sie in einer
         //  Sprachversion existiert (pfad/dateiname.lang.suffix), die statt des Originalnamens genutzt wird.
+        /** @return boolean|string */
 
+        /**
+         *  @return string
+         */
         function getDocumentName( )
         {
             // Zerlege den Pfadnamen in path, name, lang und suffix.
@@ -92,12 +168,12 @@ if( !class_exists('help_documentation') )
             $filepath = $this->dir . $this->filename;
             $pattern = '/^(?<path>(.*?\/)*)(?<name>.*?)(?<lang>\.[a-zA-Z]{2})?(?<suffix>\.\w+)$/';
             if( !preg_match( $pattern, $filepath, $pathinfo ) ) {
-                return false;
+                return '';
             }
             $pathinfo = array_filter( $pathinfo, 'is_string', ARRAY_FILTER_USE_KEY );
 
             // Suche zunächst die Datei mit dem aktuellen Sprachcode
-            $pathinfo['lang'] = '.' . rex_i18n::getLanguage();
+            $pathinfo['lang'] = '.' . \rex_i18n::getLanguage();
             $real_path = realpath( implode('',$pathinfo) );
             if( !$real_path)
             {
@@ -112,24 +188,28 @@ if( !class_exists('help_documentation') )
                 if( 0 == strcasecmp($this->dir,$real_dir) )
                 {
                     $filename = substr($real_path,$this->dirLen);
-                    if( 0 == strcasecmp(substr($filename,0,5),'docs'.DIRECTORY_SEPARATOR)
+                    $xxx = in_array( $filename,$this->prohibited );
+                    if( ( 0 == strcasecmp(substr($filename,0,5),'docs'.DIRECTORY_SEPARATOR)
                      || 0 == strcasecmp($filename,'readme.md')
                      || 0 == strcasecmp($filename,'changelog.md')
                      || 0 == strcasecmp($filename,'credits.md')
                      || 0 == strcasecmp($filename,'license.md') )
+                     && !in_array( $filename,$this->prohibited ) )
                     {
                         return $filename;
                     }
                 }
             }
-            return false;
+            return '';
         }
 
+        /** @return string */
         function getFilePath()
         {
-            return $this->targetfile ? $this->dir . $this->targetfile : false;
+            return $this->targetfile ? $this->dir . $this->targetfile : '';
         }
 
+        /** @return boolean */
         function isAsset( )
         {
             return 'md' !== $this->filetype;
@@ -138,15 +218,17 @@ if( !class_exists('help_documentation') )
         //  Nicht-Markdown-Dateien (meist Bilder), werden direkt ausgegeben.
         //  Danach abbrechen.
         //  Non-Images als Download-Anhang senden
+        /** @return void */
 
-        function sendAsset( ){
-            rex_response::cleanOutputBuffers();
-            if ( ($path = $this->getFilePath()) && rex_media::isDocType($this->filetype) ) {
-                $mime = rex_file::mimeType( $path );
+        function sendAsset( ): void
+        {
+            \rex_response::cleanOutputBuffers();
+            if ( ($path = $this->getFilePath()) && \rex_media::isDocType($this->filetype) ) {
+                $mime = \rex_file::mimeType( $path );
                 if( 'image/' === substr($mime,0,6) ) {
-                    rex_response::sendFile( $path, $mime );
+                    \rex_response::sendFile( $path, $mime );
                 } else {
-                    rex_response::sendFile( $path, $mime, 'attachment', basename($path) );
+                    \rex_response::sendFile( $path, $mime, 'attachment', basename($path) );
                 }
             } else {
                 header( 'HTTP/1.1 Not Found' );
@@ -156,8 +238,12 @@ if( !class_exists('help_documentation') )
 
         //  Entferne ein für die Github-Ansicht eingebautes Menü, das hier der $navigation entspricht
         //  Das sind alle Zeilen ab Zeile 1, die mit "> - " beginnen sowie die abschließende Leerzeile
+        /**
+         *  @param string $text
+         *  @return string
+         */
 
-        function stripGithubNavigation( $text )
+        function stripGithubNavigation( string $text ): string
         {
             return preg_replace( '/^(\>\s+\-\s?.*?\\n)*\s*\\n/', '', $text );
         }
@@ -167,8 +253,12 @@ if( !class_exists('help_documentation') )
         //  Der Link ist die URL der aktuellen Seite mit dem zusätzlichen Parameter '&doc=originallink'
         //  per EP kann der Link noch einmal umgearbeitet werden.
         //  Datei die Code-Blöcke auslassen
+        /**
+         *  @param string $text
+         *  @return string
+         */
 
-        function replaceLinks( $text )
+        function replaceLinks( string $text ): string
         {
             $request = $_REQUEST;
             $request['doc'] = dirname($this->targetfile);
@@ -195,7 +285,8 @@ if( !class_exists('help_documentation') )
                     if( !$link
                      || '#' == substr($link,0,1)
                      || '?' == substr($link,0,1)
-                     || preg_match( '/^.*?\:\/\/.*?$/',$link) )
+                     || preg_match( '/^.*?\:\/\/.*?$/',$link)
+                     || ('' === ($href = help_documentation::getLink( $request, $link, $docfile ))) )
                     {
                         $term = $matches[0];
                         $href = $link;
@@ -203,10 +294,14 @@ if( !class_exists('help_documentation') )
                     //  alle anderen Varianten umbauen
                     else
                     {
-                        $href = help_documentation::getLink( $request, $link );
-                        $term = $matches[1] . $href . $matches[5];
+                        // gesperrte Seite => ohne Link
+                        if( in_array($docfile,$this->prohibited) ) {
+                            $term = $matches[3];
+                        } else {
+                            $term = $matches[1] . $href . $matches[5];
+                        }
                     }
-                    return rex_extension::registerPoint(new rex_extension_point(
+                    return \rex_extension::registerPoint(new \rex_extension_point(
                         'HELP_HREF',
                         $term,
                         ['source'=>$matches[0],'label'=>$matches[3],'link'=>$matches[4],'href'=>$href,'isImageLink'=>($matches[2]>''),'context'=>$this->context]
@@ -222,13 +317,21 @@ if( !class_exists('help_documentation') )
             return $text;
         }
 
-        static function getLink( $request, $link )
+        /**
+         *  @param array<mixed> $request    Entspricht $_REQUEST
+         *  @param string $link             URL, die bearbeitet wird
+         *  @param string $docfile
+         *  @return string                  Aus dem Link ermittelte neue, BE-bazogene URL
+         */
+        static function getLink( $request, $link, &$docfile=null )
         {
             $url = '';
             if( preg_match('/^(?<link>.*?)(#(?<hook>.*?))?$$/',$link,$linkinfo) ){
                 if( $linkinfo['link'] ?? '' ) $request['doc'] .= DIRECTORY_SEPARATOR . $linkinfo['link'];
-                $url = rex_url::currentBackendPage( $request,false );
+                if( isset($request['_pjax']) ) unset($request['_pjax']);
+                $url = \rex_url::currentBackendPage( $request,false );
                 if( $linkinfo['hook'] ?? '' ) $url .= '#' . $linkinfo['hook'];
+                $docfile = $request['doc'];
             }
             return $url;
         }
@@ -237,19 +340,66 @@ if( !class_exists('help_documentation') )
         //  Es wird nicht beim einzelnen Aufruf geprüft, ob es sinnvolle Referenzen im $navigation-Array
         //  gibt. Das muss der Entwickler sicherstellen.
         //  Der Link ist die URL der aktuellen Seite mit dem zusätzlichen Paramater 'doc=seitenlink'
+        /**
+         *  @param array<mixed> $navigation
+         *  @param array<mixed> $request
+         *  @return array<mixed>
+         */
 
-        function getNavigation( ){
+        function getNavArray( array $navigation, array $request ) : array
+        {
             $tabs = [];
-            $request = $_REQUEST;
-            foreach( $this->navigation as $nav )
+            foreach( $navigation as $nav )
             {
                 $href = $nav['href'] ?? '' ?: '';
                 if( isset($nav['path']) && $nav['path'] ){
                     $request['doc'] = $nav['path'] ?? '' ?: '';
-                    $href = rex_url::currentBackendPage( $request,false );
+                    $href = \rex_url::currentBackendPage( $request,false );
                 }
                 if( $href ) {
-                    $tabs[] = [
+                    $active = $this->filename == ($nav['path'] ?? '' ?: '');
+                    $tab = [
+                        'linkClasses' => [],
+                        'itemClasses' => [],
+                        'linkAttr' => [],
+                        'itemAttr' => [],
+                        'href' => $href,
+                        'title' => $nav['title'] ?? '' ?: '',
+                        'icon' => $nav['icon'] ?? false ?: false
+                    ];
+                    $active = false;
+                    if( is_array($nav['subnav']??null) ) {
+                        $subnav = $this->getNavArray( $nav['subnav'], $request );
+                        $active = array_reduce( $subnav, function($c,$v){return $c || $v['active'];}, false );
+                        if( $active ) {
+                            $tab['children'] = $subnav;
+                        }
+                    }
+                    $tab['active'] = $active || ($this->filename == ($nav['path'] ?? '' ?: ''));
+                    $tabs[] = $tab;
+                }
+            }
+            return $tabs;
+        }
+
+        /**
+         *  @param array<mixed> $navigation
+         *  @param array<mixed> $request
+         *  @return array<mixed>
+         */
+        function getNavigationStructure( array $navigation, array $request ) : array
+        {
+            $tabs = [];
+            $active = false;
+            foreach( $navigation as $nav )
+            {
+                $href = $nav['href'] ?? '' ?: '';
+                if( isset($nav['path']) && $nav['path'] ){
+                    $request['doc'] = $nav['path'] ?? '' ?: '';
+                    $href = \rex_url::currentBackendPage( $request,false );
+                }
+                if( $href ) {
+                    $tab = [
                         'linkClasses' => [],
                         'itemClasses' => [],
                         'linkAttr' => [],
@@ -259,15 +409,30 @@ if( !class_exists('help_documentation') )
                         'active' => $this->filename == ($nav['path'] ?? '' ?: ''),
                         'icon' => $nav['icon'] ?? false ?: false
                     ];
+                    if( is_array($nav['subnav']??null) ) {
+                        $subnav = $this->getNavigationStructure( $nav['subnav'], $request );
+                        if( $subnav ) {
+                            $tab['children'] = $subnav;
+                            $tab['active'] = true;
+                        }
+                    }
+                    $tabs[] = $tab;
+                    $active = $active || $tab['active'];
                 }
             }
-            $tabs = rex_extension::registerPoint(new rex_extension_point(
+            return $active ? $tabs : [];
+        }
+
+        function getNavigation( ) : string
+        {
+            $tabs = \rex_extension::registerPoint(new \rex_extension_point(
                 'HELP_NAVIGATION',
-                $tabs, ['profile'=>$this->navigation,'context'=>$this->context]
+                $this->getNavArray( $this->navigation, $_REQUEST ),
+                ['profile'=>$this->navigation,'context'=>$this->context]
             ));
             if( $tabs )
             {
-                $fragment = new rex_fragment();
+                $fragment = new \rex_fragment();
                 $fragment->setVar('left', $tabs, false);
                 return $fragment->parse('core/navigations/content.php');
             }
@@ -277,10 +442,10 @@ if( !class_exists('help_documentation') )
         //  Die Markdown-Datei wird in Inhaltsverzeichnis und Inhalt aufgedröselt
         //  beide stehen nebeneinander in zwei Spalten.
 
-        function getDocument( $text )
+        function getDocument( string $text ) : string
         {
-            [$toc, $content] = rex_markdown::factory()->parseWithToc( $text,2,3,false );
-            $fragment = new rex_fragment();
+            [$toc, $content] = \rex_markdown::factory()->parseWithToc( $text,2,3,false );
+            $fragment = new \rex_fragment();
             $fragment->setVar('content', $content, false);
             $fragment->setVar('toc', $toc, false);
             return $fragment->parse('core/page/docs.php');
@@ -289,19 +454,19 @@ if( !class_exists('help_documentation') )
         //  Wenn es im Addon-Asset-Verzeichnis Ressourcen-Dateien gibt, werden sie geladen
         //  /assests/addons/myaddon/help.min.js bzw. /assests/addons/myaddon/help.min.css
 
-        function getJsCss( )
+        function getJsCss( ): string
         {
             $HTML = '';
             $path = $this->context->getAssetsPath('help.min.js');
             if( file_exists($path) ){
                 $file = $this->context->getAssetsUrl('help.min.js');
-                $url = rex_url::backendController(['asset' => $file, 'buster' => filemtime($path)]);
+                $url = \rex_url::backendController(['asset' => $file, 'buster' => filemtime($path)]);
                 $HTML .= '<script type="text/javascript" src="' . $url .'"></script>';
             }
             $path = $this->context->getAssetsPath('help.min.css');
             if( file_exists($path) ){
                 $file = $this->context->getAssetsUrl('help.min.css');
-                $url = rex_url::backendController(['asset' => $file, 'buster' => filemtime($path)]);
+                $url = \rex_url::backendController(['asset' => $file, 'buster' => filemtime($path)]);
                 $HTML .= '<link rel="stylesheet" type="text/css" media="all" href="' . $url .'" />';
             }
             return $HTML;
@@ -318,17 +483,24 @@ if( $publish->isAsset() ) {
     $publish->sendAsset();
 }
 
-$text = '';
-if( $path = $publish->getFilePath() ) {
+if( '' === ($path = $publish->getFilePath()) ) {
 
-    $text = rex_file::get( $path );
+    $key = $this->getName() . '_helpphp_not_found';
+    if( !\rex_i18n::hasMsg($key) ) {
+        \rex_i18n::addMsg($key, '#Sorry, die angeforderte Seite existiert nicht oder ist gesperrt!');
+    }
+    $text = \rex_i18n::msg($key);
+
+} else {
+
+    $text = \rex_file::get( $path );
 
     $text = $publish->stripGithubNavigation( $text );
     $text = $publish->replaceLinks( $text );
-
-    $text = $publish->getDocument( $text );
-
 }
+
+$text = $publish->getDocument( $text );
+
 ?>
 <?=$publish->getJsCss()?>
 <div class="help-documentation">

--- a/install.php
+++ b/install.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     3.0.2
+ *  @version     4.0.2
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -19,6 +19,8 @@
  *
  *  As well we have to cover that a field "med_focuspoint" might already exists from other sources
  *  with a different meta-type.
+ *
+ *  @var rex_addon $this
  */
 
 // make addon-parameters available
@@ -147,7 +149,7 @@ if( $meta_action_type && !$message ) {
 }
 
 if( $meta_action_field && !$message ) {
-    $result = rex_metainfo_add_field('translate:focuspoint_field_label', rex_effect_abstract_focuspoint::MED_DEFAULT, '', '', $meta_type_id, '', '', '', '');
+    $result = rex_metainfo_add_field('translate:focuspoint_field_label', rex_effect_abstract_focuspoint::MED_DEFAULT, 0, '', $meta_type_id, '', '', '', '');
     if( true === $result ) {
         $successMsg[] = rex_i18n::msg( 'focuspoint_install_field_ok', rex_effect_abstract_focuspoint::MED_DEFAULT );
         $meta_action_connect = false; // impliziet beim Anlegen durchgeführt
@@ -189,6 +191,8 @@ if ( $mm_action_type && !$message ) {
 
 if ( $mm_action_effect && !$message ) {
     $sql->setTable( $db_mmeffect );
+    // Auch wenn rexstan hier meckert, ist es passed so.
+    // @phpstan-ignore-next-line 
     $sql->setValue( 'type_id', $mm_type_id );
     $sql->setValue( 'effect', 'resize' );
     $sql->setValue( 'parameters', '{"rex_effect_resize":{"rex_effect_resize_width":"1024","rex_effect_resize_height":"1024","rex_effect_resize_style":"maximum","rex_effect_resize_allow_enlarge":"enlarge"}}' );

--- a/lib/effect_focuspoint.php
+++ b/lib/effect_focuspoint.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     2.0.3
+ *  @version     4.0.2
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -19,12 +19,6 @@
  *  Eigene Fokuspunkt-Effekte sollten unbedingt hiervon abgeleitet werden, nie direkt von
  *  "rex_effect_abstract"!
  *
- *  @method array|false str2fp( string $xy, array $wh=null )
- *  @method array rel2px( array $xy, array $wh )
- *  @method array getDefaultFocus( array $default=null, array $wh=null )
- *  @method string getMetaField()
- *  @method array getFocus( focuspoint_media|null $media, array $default=null, array $wh=null )
- *  @method array getParams()
  */
 
 abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
@@ -36,7 +30,11 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
     const HTML_PATTERN = '^(100|[1-9]?[0-9])\.[0-9],(100|[1-9]?[0-9])\.[0-9]$';
     const PATTERN = '/^(?<x>(100|[1-9]?\d)\.\d),(?<y>(100|[1-9]?\d)\.\d)$/';
     const STRING = '%3.1F,%3.1F';
+
+    /** @var array<int> */
     static $mitte = [50,50];
+    
+    /** @var array<string> */
     static $internalEffects = [ 'focuspoint_fit', 'focuspoint_resize' ];
 
     /**
@@ -44,13 +42,13 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
      *
      *  Ist der Parameter $wh angegeben, werden die Koordinaten in absolute Werte umgerechnet.
      *
-     *  @param  string $xy  Zeichenkette mit dem Koordinaten-Paar ("12.3,34.5")
-     *  @param  array  $wh  Array [breite,höhe] mit den Referenzwerten, auf die sich
-     *                      die Prozentwerte der Koordinaten beziehen.
+     *  @param  string          $xy     Zeichenkette mit dem Koordinaten-Paar ("12.3,34.5")
+     *  @param  array<mixed>    $wh     Array [breite,höhe] mit den Referenzwerten, auf die sich
+     *                                  die Prozentwerte der Koordinaten beziehen.
      *
-     *  @return array|null  [x,y] als Koordinaten-Array oder null für ungültiger String
+     *  @return array<float>|bool       [x,y] als Koordinaten-Array oder false für ungültiger String
      */
-    static public function str2fp( $xy, array $wh=null )
+    static public function str2fp( string $xy, array $wh=null )
     {
         if( $i = preg_match_all( self::PATTERN, (string)$xy, $tags ) )
         {
@@ -65,10 +63,10 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
     /**
      *  rechnet relative Fokuspunkt-Koordinaten in absolute um.
      *
-     *  @param  array $xy   Array [x,y] der relativen Koordinaten (0..100)
-     *  @param  array $wh   Array [breite,höhe] der Bildabmessungen
+     *  @param  array<mixed>    $xy     Array [x,y] der relativen Koordinaten (0..100)
+     *  @param  array<mixed>    $wh     Array [breite,höhe] der Bildabmessungen
      *
-     *  @return array       [x,y] als absolute Werte der Fokuspunkt-Koordinate
+     *  @return array<integer>            [x,y] als absolute Werte der Fokuspunkt-Koordinate
      */
     static public function rel2px( array $xy, array $wh )
     {
@@ -84,9 +82,10 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
      *  Sollt das Feld leer sein oder ungültig, wird der angegebene $default herangezogen.
      *  Gibt es den auch nicht, wird  aus Bildmitte gesetzt.
      *
-     *  @param  array $default  Ein Array [x,y] mit den Koordinaten als Prozent der Bilddimension
+     *  @param  array<mixed>    $default    Ein Array [x,y] mit den Koordinaten als Prozent der Bilddimension
+     *  @param  array<mixed>    $wh         Array [breite,höhe] der Bildabmessungen
      *
-     *  @return array           [x,y] als Koordinaten-Array
+     *  @return array<float>                [x,y] als Koordinaten-Array
      */
     public function getDefaultFocus( array $default=null, array $wh=null )
     {
@@ -105,13 +104,11 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
      *  Das Feld 'meta' des Efektes enthält den Namen des Fokuspunkt-Meta-Feldes.
      *  steht er auf 'defaut', ist kein Meta-Feld ausgewählt.
      *
-     *  @param  array $default  Ein Array [x,y] mit den Koordinaten als Prozent der Bilddimension
-     *
-     *  @return array           [x,y] als Koordinaten-Array
+     *  @return string           Feldname
      */
     public function getMetaField()
     {
-        return substr($this->params['meta'],0,9) == 'default ' ? '' : $this->params['meta'];
+        return str_starts_with($this->params['meta'],'default ') ? '' : $this->params['meta'];
     }
 
 
@@ -124,13 +121,13 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
      *  Falls $media kein gültiges Objekt aus dem Medienpool ist (z.B. wenn der Medienpfad mit dem
      *  vorgeschalteten Effekt "mediapath" geändert wurde), werden die Defaultwerte herangezogen.
      *
-     *  @param  focuspoint_media | null $media     Media-Objekt oder null
-     *  @param  array                   $default   Default-Koordinaten falls auf anderem Wege keine
-     *                                             gültigen Koordinaten ermittelt werden können
-     *  @param  array                   $wh        Array [breite,höhe] mit den Referenzwerten, auf die
-     *                                             sich die Prozentwerte der Koordinaten beziehen.
+     *  @param  focuspoint_media    $media    Media-Objekt oder null
+     *  @param  array<mixed>        $default  Default-Koordinaten falls auf anderem Wege keine
+     *                                        gültigen Koordinaten ermittelt werden können
+     *  @param  array<mixed>        $wh       Array [breite,höhe] mit den Referenzwerten, auf die
+     *                                        sich die Prozentwerte der Koordinaten beziehen.
      *
-     *  @return array   [x,y] als Koordinaten-Array
+     *  @return array<float>                  [x,y] als Koordinaten-Array
      */
     function getFocus( $media=null, array $default=null, array $wh=null )
     {
@@ -161,7 +158,7 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
      *      * Auswahl des genutzten Meta-Feldes oder "default" für "Default-Koordinaten"
      *      * Eingabefeld für die Default-Koordinaten
      *
-     *  @return array   Felddefinitionen
+     *  @return array<mixed>   Felddefinitionen
      */
     public function getParams()
     {

--- a/lib/effect_focuspoint_fit.php
+++ b/lib/effect_focuspoint_fit.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     2.1.2
+ *  @version     4.0.2
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -44,19 +44,16 @@
  *  zweiter Buchstabe ist die Verwendung: Offset (x bzw. y), Höhe (h), Breite (w), AspectRatio (r)
  *  Beispiel: $dw, $dh, $dr
  *
- *  @method string getName()
- *  @method void execute()
- *  @method array getParams()
- *  @method int|float|null decodeSize( string $value, $ref=0 )
  */
 
 
 
 class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
 {
-    private $optionsZoom = ['0%','25%', '50%', '75%','100%'];
+	/** @var array<string> */
+	private $optionsZoom = ['0%','25%', '50%', '75%','100%'];
+	/** @var integer */
     private $targetByAR;
-    private $dummy = '##';
 
     const PATTERN = '^([1-9]\d*\s*(px)?|(100|[1-9]?\d)(\.\d)?\s*%|[1-9]\d*\s*fr)$';
 
@@ -112,6 +109,8 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
 			$dw = $this->decodeSize( $this->params['width'],$sw );
 			$dh = $this->decodeSize( $this->params['height'],$sh );
 			if ( empty($dw) && empty($dh) ) return;
+			// Auch wenn rexstan hier meckert, aber es stimmt so: decodeSize incrmentiert targetByAR
+			// @phpstan-ignore-next-line 
 			if ( $this->targetByAR == 1 ) return;
 
 		/*
@@ -148,6 +147,8 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
 			und  Höhe 9fr, was 16:9 entspricht), muss das Zielformat auf die Bildgröße
 			geändert werden. Zoom ist dann irrelevant.
 		*/
+			// Auch wenn rexstan hier meckert, aber es stimmt so: decodeSize incrmentiert targetByAR
+			// @phpstan-ignore-next-line 
 			if ( $this->targetByAR == 2)
 			{
 				$dw = $too_wide ? $sh * $dr : $sw;
@@ -211,11 +212,16 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
 			return;
 		}
 
+		// Die Fehlermeldung von rexstan beruht auf der Prüfung gegen PHP8. Dort sind GD-Objekte vom Typ "GdImage" und nicht "resoource"
+		// Daher werden nachfolgend drei Zeilen ignoriert.
+		// @phpstan-ignore-next-line
 		$this->keepTransparent($des);
+		// @phpstan-ignore-next-line
 		imagecopyresampled($des, $gdimage,
 						   0, 0, $cx, $cy,
 						   $dw, $dh, $cw, $ch);
 
+		// @phpstan-ignore-next-line
 		$this->media->setImage($des);
 		$this->media->refreshImageDimensions();
 
@@ -228,7 +234,7 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
      *  Die Basisfelder werden aus der Parent-Klasse abgerufen und um die Felder für
      *  Breite und Höhe des Zielbildes sowie den Zoom-Faktor ergänzt.
      *
-     *  @return     array   Felddefinitionen
+     *  @return     array<mixed>   Felddefinitionen
      */
     public function getParams()
     {
@@ -266,10 +272,10 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
      *  mit Einheit %: über $ref in absolute Werte umrechnen
      *  mit Einheit fr: keine Fmrechnenung, aber FR-Zähler hochsetzen
      *
-     *  @var    string  $value  auszuwertende Zeichenfolge
-     *  @var    num     $ref    Referenzwert (Breite oder Höhe des Bildes)
+     *  @param    string        $value  auszuwertende Zeichenfolge
+     *  @param    float|int     $ref    Referenzwert (Breite oder Höhe des Bildes)
      *
-     *  @return num|null    umgerechneter Wert oder null für ungültiges Format
+     *  @return   float|null    umgerechneter Wert oder null für ungültiges Format
      */
     function decodeSize( $value, $ref=0 )
     {

--- a/lib/focuspoint.php
+++ b/lib/focuspoint.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.0.0
+ *  @version     4.0.2
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -14,18 +14,6 @@
  *
  *  Die Klasse "focuspoint" stellt Service-Funktionen bereit, die in Extension-Points
  *  aufgerufen werden
- *
- *  @method string show_sidebar( rex_extension_point $ep )
- *  @method array customfield( rex_extension_point $ep )
- *  @method string checkUninstallDependencies( )
- *  @method string checkActivateDependencies( )
- *  @method string checkDeactivateDependencies( )
- *  @method string metafield_is_in_use( rex_extension_point $ep )
- *  @method array getMetafieldList( $extern=false )
- *  @method array getFocuspointMetafieldInUse( string $feld )
- *  @method array getFocuspointEffects( $extern=false )
- *  @method array getFocuspointEffectsInUse( )
- *  @method string getFocuspointEffectsInUseMessage( array $effekte )
  */
 
 class focuspoint
@@ -52,6 +40,8 @@ class focuspoint
      *  @return string|void   modifiziertes Sidebar-Html | keine Änderung
      */
 
+    // rexstan meldet: "Method focuspoint::show_sidebar() has parameter $ep with generic class rex_extension_point but does not specify its types: T"
+    // Warum?? Einfach ignorieren
     public static function show_sidebar( rex_extension_point $ep )
     {
         $params = $ep->getParams();
@@ -134,9 +124,11 @@ class focuspoint
      *
      *  @param  rex_extension_point $ep
      *
-     *  @return array   Metafield-Html, ....
+     *  @return array<mixed>|void   Metafield-Html, ....
      */
 
+    // rexstan meldet: "Method focuspoint::customfield() has parameter $ep with generic class rex_extension_point but does not specify its types: T"
+    // Warum?? Einfach ignorieren
     public static function customfield( rex_extension_point $ep )
     {
         $subject = $ep->getSubject();
@@ -151,8 +143,7 @@ class focuspoint
         // as of V2.2 the fields are still available just for not cousing a BC.
         // A future V3.0 will instead stop generating the HTML.
         $hidden = rex::getProperty('focuspoint_no_image',false) === true;
-        # V3.0: if( rex::getProperty('focuspoint_no_image',false) === true ) return;
-
+    
         $feld = new rex_fragment();
         $feld->setVar( 'label', $subject[4], false );
         $feld->setVar( 'id', $subject[3] );
@@ -275,15 +266,15 @@ class focuspoint
      *  Identifizierungsmerkmal ist im Feld "parameters" von rex_media_manager_type_effect der
      *  Eintrag "rex_effect_«focuspunktfeld»_meta":"«metafeld»".
      *
-     *  @param  int $id Nummer des Feldes (Datensatz-Id in rex_metainfo_field)
-     *  @return string  leerer String oder Rückmeldung der gefundenen Einträge
+     *  @param  int          $id Nummer des Feldes (Datensatz-Id in rex_metainfo_field)
+     *  @return string       leerer String oder Rückmeldung der gefundenen Einträge
      */
 
     public static function metafield_is_in_use( $id )
     {
         // Name des zu löschenden Metafeldes
         $feld = self::getMetafieldList( );
-        if( !isset( $feld[$id] ) ) return;
+        if( !isset( $feld[$id] ) ) return '';
         $feld = $feld[$id];
 
         // Das Default-Feld "med_focuspoint" darf so oder so nie gelöcht werden.
@@ -313,7 +304,7 @@ class focuspoint
      *  @param  bool $extern    wenn true werden nur Felder geliefert, die zusätzlich zum
      *                          AddOn-eigenen Feld "med_fosuspunkt" angelegt wurden
      *
-     *  @return array           Key/Value-Array mit id=>name
+     *  @return array<mixed>   Key/Value-Array mit id=>name
      */
 
     public static function getMetafieldList( $extern=false )
@@ -336,7 +327,7 @@ class focuspoint
      *  rex_effect_abstract_focuspoint erzeugt und nutze das Parameterfeld "meta".
      *
      *  @param  string $feld  Name des Fokuspunkt-Metafeldes
-     *  @return array         Array mit einem Subarray je Type/Effekt mit
+     *  @return array<mixed>  Array mit einem Subarray je Type/Effekt mit
      *                          name        => Name des Typ
      *                          type_id     => id des Typs "name" (rex_media_manager_type)
      *                          effect      => Name des eingesetzten Fokuspunkt-Effektes
@@ -368,7 +359,7 @@ class focuspoint
      *  @param  bool $extern    wenn true werden nur Effekte ermittelt, die zusätzlich zu den
      *                          AddOn-eigenen Effekten beim Media-Manager registriert wurden.
      *
-     *  @return array           Key/Value-Array mit rex_effect_«name»=>«name»
+     *  @return array<string>   Key/Value-Array mit rex_effect_«name»=>«name»
      */
 
     public static function getFocuspointEffects( $extern=false )
@@ -389,12 +380,12 @@ class focuspoint
      *  Die Funktion ermittelt die Liste aller Fokuspunkt-Effekte, die in einem Media-Manager-Typ
      *  eingesetzt sind.
      *
-     *  @return array   Array mit einem Subarray je Type/Effekt mit
-     *                      name        => Name des Typ
-     *                      type_id     => id des Typs "name" (rex_media_manager_type)
-     *                      effect      => Name des eingesetzten Fokuspunkt-Effektes
-     *                      id          => id des effektes (rex_media_manager_type_effect)
-     *                      parameters  => Parameter des Effektes
+     *  @return array<mixed>   Array mit einem Subarray je Type/Effekt mit
+     *                          name        => Name des Typ
+     *                          type_id     => id des Typs "name" (rex_media_manager_type)
+     *                          effect      => Name des eingesetzten Fokuspunkt-Effektes
+     *                          id          => id des effektes (rex_media_manager_type_effect)
+     *                          parameters  => Parameter des Effektes
      */
 
     public static function getFocuspointEffectsInUse( )
@@ -413,7 +404,7 @@ class focuspoint
     /**
      *  Die Funktion bereitet die angegebenen Effekte zu einer UL/LI-Meldung auf.
      *
-     *  @param  array $effekte
+     *  @param  array<mixed> $effekte
      *  @return string
      */
 

--- a/lib/focuspoint_api.php
+++ b/lib/focuspoint_api.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     2.0
+ *  @version     4.0.2
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -32,7 +32,6 @@
  *               &type=      Name des MM-Effektes
  *               &xy=        Fokuspunkt numerisch (0.0,0.0 bis 100.1,100.0)
  *
- *  @method void function execute()
  */
 
  class rex_api_focuspoint extends rex_api_function {
@@ -63,7 +62,6 @@
 *  Da die wichtige Funktion rex_media_manager->applyEffects 'protected' ist, muss eine abgeleitete
 *  Klasse "focuspoint_media_manager" zwischengeschaltet werden, um das neue Bild zu generieren.
 *
-*  @method rex_managed_media createMedia( string $type=null, string $file=null )
 */
 class focuspoint_media_manager extends rex_media_manager
 {
@@ -77,13 +75,12 @@ class focuspoint_media_manager extends rex_media_manager
      */
     public static function createMedia( $type=null, $file=null )
     {
-        $media = new rex_managed_media( rex_path::media( $file ) );
-        $manager = new self( $media );
-        $manager->deleteCache( $file, $type );
-        $manager->setCachePath($cachePath);
-        $manager->applyEffects( $type );
-        $media->asImage();
-        $manager->deleteCache( $file, $type );
+        $mediaPath = rex_path::media($file);
+        $media = new rex_managed_media($mediaPath);
+        $manager = new self($media);
+        $manager->setCachePath('');
+        $manager->applyEffects($type);
+        $media->refreshImageDimensions();
         return $media;
     }
 }

--- a/lib/focuspoint_boot.php
+++ b/lib/focuspoint_boot.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     3.0.0
+ *  @version     4.0.2
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -16,13 +16,6 @@
  *  Die Aktivitäten wurden in eine separate Datei ausgelagert, um für den Normalbetrieb der
  *  REDAXO-Instanz eine schlanke boot.php mit geringem Kompilieraufwand zu haben.
  *
- *
- *  @method void function mediaDetailPage( rex_addon $fpAddon )
- *  @method void function metainfoDefault()
- *  @method void function metainfoMedia()
- *  @method void function media_managerTypes()
- *  @method void function packages( rex_addon $fpAddon )
-
  */
 
 class focuspoint_boot {
@@ -31,6 +24,9 @@ class focuspoint_boot {
      *  page=mediapool/media
      *
      *  Ressourcen für die Fokuspunkt-Erfassung im Mediapool einbinden
+     * 
+     *  @param rex_addon $fpAddon
+     *  @return void
      */
     static public function mediaDetailPage( $fpAddon )
     {
@@ -46,6 +42,8 @@ class focuspoint_boot {
      *  page=metainfo/clangs
      *
      *  Auswahl des Metainfo-Datentyp "focuspoint (AddOn)" ausblenden da nur für Medien relevant
+     * 
+     *  @return void
      */
     static public function metainfoDefault()
     {
@@ -88,6 +86,8 @@ class focuspoint_boot {
      *     entsprechenden Felder gesperrt, gelöscht oder begrenzt. (per JS)
      *     Gilt auch für Fokuspunkt-Felder, die bereits in Effekten/Typen des MM genutzt werden.
      *  3) Liste: In der Liste der Metafelder wird ebenfalls das Default-Feld gegen Löschen gesperrt
+     * 
+     *  @return void
      */
     static public function metainfoMedia()
     {
@@ -173,8 +173,11 @@ class focuspoint_boot {
         // don´t remove the default-Metafield from the list,
         rex_extension::register( 'REX_LIST_GET', function( rex_extension_point $ep ){
             $list = $ep->getSubject();
-            $effectsInUse = focuspoint::getFocuspointEffectsInUse();
-            $list->setColumnFormat('delete', 'custom', function ($params) use($effectsInUse) {
+# Erkenntnis aus rexstan: $effectsInUse wird in der custom-function nicht (mehr) benutzt.
+# Erst mal als Kommentar im Code belassen
+#            $effectsInUse = focuspoint::getFocuspointEffectsInUse();
+#            $list->setColumnFormat('delete', 'custom', function ($params) use($effectsInUse) {
+            $list->setColumnFormat('delete', 'custom', function ($params) {
                 $list = $params['list'];
                 if( $list->getValue('name') == rex_effect_abstract_focuspoint::MED_DEFAULT ) {
                     return '<small class="text-muted">' . rex_i18n::msg('focuspoint_doc') . '</small>';
@@ -194,6 +197,8 @@ class focuspoint_boot {
      *  Verhindert in der Liste der verfügbaren Media-Manager-Typen bzw. im Edit-Formular,
      *  dass der von Focuspoint selbst benötigte Media-Manager-Typ "rex_effect_abstract_focuspoint::MM_TYPE"
      *  gelöscht oder sein Name verändert wird.
+     * 
+     *  @return void
      */
     static public function media_managerTypes()
     {
@@ -259,7 +264,7 @@ class focuspoint_boot {
             $sql->setQuery($qry, [rex_request('type_id', 'int'),rex_effect_abstract_focuspoint::MM_TYPE]);
             if( $sql->getRows() ) {
                 $_REQUEST['func'] = '';
-                rex_extension::register('PAGE_TITLE_SHOWN', function(rex_extension_point $ep) use ($result) {
+                rex_extension::register('PAGE_TITLE_SHOWN', function(rex_extension_point $ep) {
                     $result = rex_i18n::msg('focuspoint_isinuse_dontdeletedefault',rex_effect_abstract_focuspoint::MM_TYPE);
                     $ep->setSubject(rex_view::error($result) . $ep->getSubject());
                 });
@@ -271,6 +276,9 @@ class focuspoint_boot {
      *  page=packages
      *
      *  leitet auf einen spezialisierten API-Handler um.
+     * 
+     *  @param rex_addon $fpAddon
+     *  @return void
      */
     static public function packages( $fpAddon )
     {

--- a/lib/focuspoint_media.php
+++ b/lib/focuspoint_media.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     2.1
+ *  @version     4.0.2
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -15,23 +15,10 @@
  *  Die Klasse "focuspoint_media" ist von "rex_media" abgeleitet und erleichetrt den
  *  Umgang mit Medien, deren Darstellung auf Fokuspunkten basiert.
  *
- *  @method __construct( )
- *  @method focuspoint_media get( string $name )
- *  @method array getFocus( string $metafield = null, array $default = null, $wh=false )
- *  @method bool hasFocus( string $metafield = null )
  */
 
 class focuspoint_media extends rex_media
 {
-
-
-    /**
-     * Necessary for PHP 5.6
-     */
-    public function __construct()
-    {
-    }
-
 
     /**
      *  Gibt die Bildinstanz zurück und prüft dabei ab, ob es ein Bild ist (isImage).
@@ -64,15 +51,15 @@ class focuspoint_media extends rex_media
      *  Die als $default und $wh angegebenen Array müssen format korrekt sein.
      *  Das wird nicht überprüft. Also [x,y] mit x|y von 0.0 bis 100.0.
      *
-     *  @param  string $metafield   Metafeld, aus dem die Koordinaten entnommen werden.
-     *                              default: med_focuspoint
-     *  @param  array  $default     Default-Koordinaten falls das Metafeld leer oder ungültig ist.
-     *                              Wenn $default fehlt: 50,50
-     *  @param  array  $wh          Array [breite,höhe] mit den absoluten Referenzwerten, auf die
-     *                              sich die Prozentwerte der Koordinaten beziehen, oder True für
-     *                              [bildbreite,bildhöhe].
+     *  @param  string             $metafield  Metafeld, aus dem die Koordinaten entnommen werden.
+     *                                          default: med_focuspoint
+     *  @param  array<mixed>       $default    Default-Koordinaten falls das Metafeld leer oder ungültig ist.
+     *                                          Wenn $default fehlt: 50,50
+     *  @param  array<mixed>|bool   $wh         Array [breite,höhe] mit den absoluten Referenzwerten, auf die
+     *                                          sich die Prozentwerte der Koordinaten beziehen, oder True für
+     *                                          [bildbreite,bildhöhe].
      *
-     *  @return array  [x,y] als Koordinaten-Array
+     *  @return array<float>                    [x,y] als Koordinaten-Array
      */
     function getFocus( $metafield = null, array $default = null, $wh=false )
     {
@@ -102,10 +89,10 @@ class focuspoint_media extends rex_media
      *  (1) das angegebene Fokuspunkt-Metafeld existiert und
      *  (2) das Feld einen formal gültigen Wert liefert.
      *
-     *  @param  string $metafield   Metafeld, aus dem die Koordinaten entnommen werden.
-     *                              default: med_focuspoint
+     *  @param  string     $metafield   Metafeld, aus dem die Koordinaten entnommen werden.
+     *                                  default: med_focuspoint
      *
-     *  @return bool   true, false
+     *  @return bool                        
      */
     function hasFocus( $metafield = null )
     {

--- a/lib/focuspoint_reflection.php
+++ b/lib/focuspoint_reflection.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     2.2.0
+ *  @version     4.0.2
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -17,32 +17,50 @@
  *
  *  HANDLE WITH CARE!
  *
- *  @method void function executeMethod ($method, array $params)
- *  @method void function getPropertyValue ( $prop )
- *  @method void function setPropertyValue ( $prop, $value )
  */
 
+// rexstan meldet: "Class focuspoint_reflection extends generic class ReflectionClass but does not specify its types: T"
+// Warum?? Einfach ignorieren
 class focuspoint_reflection extends ReflectionClass {
 
+    /** @var object */
     public $obj = null;
 
+    /**
+     *  @param object $obj
+     *  @return void
+     */
     function __construct( $obj ) {
         parent::__construct( $obj );
         $this->obj = $obj;
     }
 
+    /**
+     *  @param string $method
+     *  @param array<mixed> $params
+     *  @return mixed
+     */
     function executeMethod ($method, array $params){
         $method = $this->getMethod( $method );
         $method->setAccessible(true);
         return $method->invokeArgs($this->obj, $params);
     }
 
+    /**
+     *  @param string $prop
+     *  @return mixed
+     */
     function getPropertyValue ( $prop ) {
         $property = $this->getProperty($prop);
         $property->setAccessible(true);
         return $property->getValue( $this->obj );
     }
 
+    /**
+     *  @param string $prop
+     *  @param mixed $value
+     *  @return void
+     */
     function setPropertyValue ( $prop, $value ) {
         $property = $this->getProperty($prop);
         $property->setAccessible(true);

--- a/lib/package_api.php
+++ b/lib/package_api.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     2.0
+ *  @version     4.0.2
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -32,7 +32,6 @@
  *               &type=      Name des MM-Effektes
  *               &xy=        Fokuspunkt numerisch (0.0,0.0 bis 100.1,100.0)
  *
- *  @method void function execute()
  */
 
  class rex_api_focuspoint_package extends rex_api_package {
@@ -62,6 +61,8 @@
               throw new rex_api_exception('Package "' . $packageId . '" doesn\'t exists!');
           }
           $reinstall = 'install' === $function && $package->isInstalled();
+          // Die rexstan-Fehlermeldung beruht vermutlich auf Bezügen zu rex_package; ist aber hier nicht lösbar. 
+          // @phpstan-ignore-next-line
           $manager = rex_package_manager::factory($package);
           try {
               $package->includeFile('precheck.php', [ 'request' => ($reinstall ? 'reinstall' : $function) ] );

--- a/uninstall.php
+++ b/uninstall.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     2.0
+ *  @version     4.0.2
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -22,6 +22,8 @@
  *  2) Lösche die zuvor installierten Standards
  *      - Meta-Feld "med_focuspoint"
  *      - Meta-Typ "Focuspoint (AddOn)"
+ *
+ *  @var rex_addon $this
  */
 
 // make addon-parameters available

--- a/update.php
+++ b/update.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     2.0
+ *  @version     4.0.2
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -15,6 +15,7 @@
  *
  *  SQL-transaction is rolled back in case of update-errors
  *
+ *  @var rex_addon $this
  */
 
 if (rex_string::versionCompare($this->getVersion(), '2.0', '<'))
@@ -55,7 +56,7 @@ if (rex_string::versionCompare($this->getVersion(), '2.0', '<'))
         else
         {
             // field does not exist. Add field
-            $result = rex_metainfo_add_field('translate:focuspoint_field_label', rex_effect_abstract_focuspoint::MED_DEFAULT, '3', '', $type_id, '', '', '', '');
+            $result = rex_metainfo_add_field('translate:focuspoint_field_label', rex_effect_abstract_focuspoint::MED_DEFAULT, 3, '', $type_id, '', '', '', '');
             if( $result !== true )
             {
                 $message = rex_i18n::msg( 'focuspoint_install_field_error', rex_effect_abstract_focuspoint::MED_DEFAULT, "<strong><i>$result</i></strong>" );
@@ -82,6 +83,7 @@ if (rex_string::versionCompare($this->getVersion(), '2.0', '<'))
                 {
 
                     $qry = 'SELECT id,med_focuspoint_data FROM '.$tab.' WHERE med_focuspoint_data > ""';
+                    /** @var array<integer,string> $liste */
                     $liste = $sql->getArray( $qry, [], PDO::FETCH_KEY_PAIR );
                     foreach( $liste as $k=>$v )
                     {
@@ -109,7 +111,9 @@ if (rex_string::versionCompare($this->getVersion(), '2.0', '<'))
                 $tab = rex::getTable('media_manager_type_effect');
                 $mitte = sprintf( rex_effect_abstract_focuspoint::STRING, rex_effect_abstract_focuspoint::$mitte[0], rex_effect_abstract_focuspoint::$mitte[1] );
                 $qry = "SELECT id,parameters FROM $tab";
-                foreach( $sql->getArray( $qry, [], PDO::FETCH_KEY_PAIR ) as $k=>$v )
+                /** @var array<integer,string> */
+                $liste = $sql->getArray( $qry, [], PDO::FETCH_KEY_PAIR );
+                foreach( $liste as $k=>$v )
                 {
                     $v = json_decode( $v, true );
                     if( isset($v['rex_effect_focuspoint_fit'] ) )
@@ -203,6 +207,14 @@ if (rex_string::versionCompare($this->getVersion(), '2.0', '<'))
 
 }
 
+
+/**
+ *  @param string|integer|float $para
+ *  @param int|float $low
+ *  @param int|float $default
+ *  @param int|float $high
+ *  @return int|float
+ */
 
 function fpUpdateNumParaOk( $para, $low=0, $default=0, $high=0 )
 {


### PR DESCRIPTION
Der PR bassiert auf den mit rexstan (phpstan) durchgeführten Code-Analysen bis Stufe 6.

Benachrichtigungen, die nicht in Focuspoint behoben werden können, sind auf `@phpstan-ignore-next-line` gesetzt. Drei weitere, deren Ursache mir nicht klar ist, sind weiterhin unbearbeitet.

Eine weiterer Anlauf, den Cache-Bug aus #110 zu lösen, ist ebenfalls enhalten (positiv getestet mit ritzfritz).

Alten Code nur für PHP 5.6 entfernt, da Focuspoint mittlerweile PHP 7.3 voraussetzt.

Und leider ist auch das Update der help.php hier mit reingelaufen statt in einen separaten PR. 