### PR TITLE
Rundungsfehler (ab PHP8.1) behoben

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## **03.01.2023 Version 4.0.3**
+
+- Bugfix: mitigates deprecated warning (PHP 8.1) or exception(PHP 8.2) when using a target sizes like "16fr/9fr" in the effect "focuspoint_fit"
+
 ## **18.06.2022 Version 4.0.2**
 
 - Another correction regarding preview issue

--- a/lib/effect_focuspoint_fit.php
+++ b/lib/effect_focuspoint_fit.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.0.2
+ *  @version     4.0.3
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -151,8 +151,8 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
 			// @phpstan-ignore-next-line 
 			if ( $this->targetByAR == 2)
 			{
-				$dw = $too_wide ? $sh * $dr : $sw;
-				$dh = $too_wide ? $sh : $sw / $dr;
+                                $dw = $too_wide ? floor($sh * $dr) : $sw;
+                                $dh = $too_wide ? $sh : floor($sw / $dr);
 				$zoom = 0;
 			}
 		/*

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package:  focuspoint
-version:  '4.0.2'
+version:  '4.0.3'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/focuspoint
 


### PR DESCRIPTION
Der Effekt "focuspoint-fit" wirft bei PHP 8.1 eine Depracated-Meldung (Implicit conversion from float 123.4567 to int loses precision) und bei PHP 8.1 eine Exception.

Auf Hinweis von @tyrant88 (#115) konnte geklärt werden, dass der Fehler nur bei Angabe der Zielgröße als "fr" passiert. Im Beispiel "16fr / 9fr". Konkret fehlt in der Umrechnung in Pixel die Glättung der Nachkommastellen mit `floor(..)`.

Der PR fügt die fehlende Glättung ein. 

closes #115