### PR TITLE
Typecast int für imagecopyresampled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## **18.03.2023 Version 4.0.4**
+
+- Bugfix: mitigates deprecated warning (PHP 8.1) or exception(PHP 8.2) when using a target sizes like "80%" in the effect "focuspoint_fit"
+
 ## **03.01.2023 Version 4.0.3**
 
 - Bugfix: mitigates deprecated warning (PHP 8.1) or exception(PHP 8.2) when using a target sizes like "16fr/9fr" in the effect "focuspoint_fit"

--- a/lib/effect_focuspoint_fit.php
+++ b/lib/effect_focuspoint_fit.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.0.3
+ *  @version     4.0.4
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE

--- a/lib/effect_focuspoint_fit.php
+++ b/lib/effect_focuspoint_fit.php
@@ -218,8 +218,8 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
 		$this->keepTransparent($des);
 		// @phpstan-ignore-next-line
 		imagecopyresampled($des, $gdimage,
-						   0, 0, $cx, $cy,
-						   $dw, $dh, $cw, $ch);
+		    0, 0, (int)$cx, (int)$cy,
+		    (int)$dw, (int)$dh, (int)$cw, (int)$ch);
 
 		// @phpstan-ignore-next-line
 		$this->media->setImage($des);

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package:  focuspoint
-version:  '4.0.3'
+version:  '4.0.4'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/focuspoint
 


### PR DESCRIPTION
Es gab immer noch deprecated-Warnungen bei der Umwandlung float/int; diesmal bei %-Werten als Zielgröße #118 