### PR TITLE
Umstellung auf Namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## **xx.xx.2024 Version 4.1.0
 
-- Umstellung auf den Namespace **FriendsOfREDAXO\focuspoint**. Aus Klasse `xyz` wird `FriendsOfREDAXO\focuspoint\xyz`. Für eine Übergangszeit ist der
+- Umstellung auf den Namespace **FriendsOfRedaxo\focuspoint**. Aus Klasse `xyz` wird `FriendsOfRedaxo\focuspoint\xyz`. Für eine Übergangszeit ist der
   alte Aufruf mit `xyz` weiterhin möglich. In der Entwicklungsumgebung sind die Aufrufe als **Deprecated** gekennzeichnet und sollten schnellstens auf die
   neue Variante umgestellt werden. Mit Version 5.0.0 wird die alte Auftufvariante endgültig entfernt.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## **xx.xx.2024 Version 4.1.0
+
+- Umstellung auf den Namespace **FriendsOfREDAXO\focuspoint**. Aus Klasse `xyz` wird `FriendsOfREDAXO\focuspoint\xyz`. Für eine Übergangszeit ist der
+  alte Aufruf mit `xyz` weiterhin möglich. In der Entwicklungsumgebung sind die Aufrufe als **Deprecated** gekennzeichnet und sollten schnellstens auf die
+  neue Variante umgestellt werden. Mit Version 5.0.0 wird die alte Auftufvariante endgültig entfernt.
+
 ## **18.03.2023 Version 4.0.4**
 
 - Bugfix: mitigates deprecated warning (PHP 8.1) or exception(PHP 8.2) when using a target sizes like "80%" in the effect "focuspoint_fit"

--- a/boot.php
+++ b/boot.php
@@ -17,7 +17,7 @@
  *  @var rex_addon $this
  */
 
-namespace FriendsOfREDAXO\focuspoint;
+namespace FriendsOfRedaxo\focuspoint;
 
 use rex;
 use rex_effect_focuspoint_fit;

--- a/boot.php
+++ b/boot.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.0.2
+ *  @version     4.1.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -17,14 +17,18 @@
  *  @var rex_addon $this
  */
 
-if (rex::isBackend())
-{
+namespace FriendsOfREDAXO\focuspoint;
 
-    switch ( rex_request('page', 'string') )
-    {
+use rex;
+use rex_effect_focuspoint_fit;
+use rex_media_manager;
+
+if (rex::isBackend()) {
+
+    switch (rex_request('page', 'string')) {
         case 'mediapool/media':
             // provide support for media detail-page
-            focuspoint_boot::mediaDetailPage( $this );
+            focuspoint_boot::mediaDetailPage($this);
             break;
 
         case 'metainfo/articles':
@@ -49,10 +53,10 @@ if (rex::isBackend())
         case 'packages':
             // prevent deactivation if in use by effects
             // effective only in dialog-mode via AddOn-administration-page
-            focuspoint_boot::packages( $this );
+            focuspoint_boot::packages($this);
             break;
     }
 
 }
 
-rex_media_manager::addEffect('rex_effect_focuspoint_fit');
+rex_media_manager::addEffect(rex_effect_focuspoint_fit::class);

--- a/docs/changes_2_0.md
+++ b/docs/changes_2_0.md
@@ -36,6 +36,8 @@ Um einen dem alten Feld vergleichbaren Wert zu erhalten, sollte die Koordinate i
 Einzelwerten abgerufen werden. Man kann die Einzelwerte nach Bedarf weiterverarbeiten.
 
 ```
+use FriendsOfREDAXO\focuspoint\focuspoint_media;
+
 $fpMedia = focuspoint_media::get( $filename );  // statt rex_media::get( $filename )
 list( $x, $y) = $fpMedia->getFocus();           // Abruf von "med_focuspoint" als [$x,$y]
 $fp = "$x%,$y%";                                // Verwendung
@@ -50,6 +52,8 @@ Wert zwischen -1 (links bzw. unten) und 1 (rechts bzw. oben).
 - neu: 50.0,60.0
 
 ```
+use FriendsOfREDAXO\focuspoint\focuspoint_media;
+
 $fpMedia = focuspoint_media::get( $filename );  // statt rex_media::get( $filename )
 list( $x_neu, $y_neu) = $fpMedia->getFocus();    // Abruf von "med_focuspoint" als [$x,$y]
 $x_alt = $x_neu / 50 - 1;                       // X-Koordinate umrechnen

--- a/docs/changes_2_0.md
+++ b/docs/changes_2_0.md
@@ -36,7 +36,7 @@ Um einen dem alten Feld vergleichbaren Wert zu erhalten, sollte die Koordinate i
 Einzelwerten abgerufen werden. Man kann die Einzelwerte nach Bedarf weiterverarbeiten.
 
 ```
-use FriendsOfREDAXO\focuspoint\focuspoint_media;
+use FriendsOfRedaxo\focuspoint\focuspoint_media;
 
 $fpMedia = focuspoint_media::get( $filename );  // statt rex_media::get( $filename )
 list( $x, $y) = $fpMedia->getFocus();           // Abruf von "med_focuspoint" als [$x,$y]
@@ -52,7 +52,7 @@ Wert zwischen -1 (links bzw. unten) und 1 (rechts bzw. oben).
 - neu: 50.0,60.0
 
 ```
-use FriendsOfREDAXO\focuspoint\focuspoint_media;
+use FriendsOfRedaxo\focuspoint\focuspoint_media;
 
 $fpMedia = focuspoint_media::get( $filename );  // statt rex_media::get( $filename )
 list( $x_neu, $y_neu) = $fpMedia->getFocus();    // Abruf von "med_focuspoint" als [$x,$y]

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -18,16 +18,16 @@
 > - [rex_api_call `focuspoint`](#api-racf)
 > - [Eigene Fokuspunkt-Effekte entwickeln](#api-mofe)
 
-Die Klassen sind mit Aussnahme von `rex_api_focuspoint` im Namensraum `FriendsOfREDAXO\focuspoint\`. Sie
+Die Klassen sind mit Aussnahme von `rex_api_focuspoint` im Namensraum `FriendsOfRedaxo\focuspoint\`. Sie
 können entweder über einen vollständigen Qualifier aufgerufen werden oder durch Einbinden am Anfang des Scriptes.
 
 ```
 ...
-$image = FriendsOfREDAXO\focuspoint\focuspoint_media::get($filename);
+$image = FriendsOfRedaxo\focuspoint\focuspoint_media::get($filename);
 ```
 
 ```
-use FriendsOfREDAXO\focuspoint\focuspoint_media;
+use FriendsOfRedaxo\focuspoint\focuspoint_media;
 ...
 $image = focuspoint_media::get($filename);
 ```
@@ -123,7 +123,7 @@ eines Addons wird der Extension-Point `MEDIA_LIST_FUNCTIONS` belegt.
 Abgefragt wird das Default-Feld "med_focuspoint":
 
 ```php
-use FriendsOfREDAXO\focuspoint\focuspoint_media;
+use FriendsOfREDAXO\FriendsOfRedaxo\focuspoint_media;
 
 if( rex_request('page', 'string') == 'mediapool/media' && !rex_request('file_id', 'string') )
 {
@@ -143,7 +143,7 @@ Falls zusätzlich individuelle Fokuspunkt-Metafelder definiert sind, kann mit di
 komplette Satz überprüft werden:
 
 ```php
-use FriendsOfREDAXO\focuspoint\focuspoint_media;
+use FriendsOfREDAXO\FriendsOfRedaxo\focuspoint_media;
 
 if( rex_request('page', 'string') == 'mediapool/media' && !rex_request('file_id', 'string') )
 {
@@ -185,7 +185,7 @@ zurückgegriffen, sondern der Fallback-Wert herangezogen.
 Die Klasse `focuspoint_media` kann z.B. in eigenen Effekten, die auf Fokuspunkten basieren,
 eingesetzt werden, aber auch in beliebigen anderen Zusammenhängen. Hier ein Beispiel :
 ```php
-use FriendsOfREDAXO\focuspoint\focuspoint_media;
+use FriendsOfRedaxo\focuspoint\focuspoint_media;
 
 $fpMedia = focuspoint_media::get( $filename );
 
@@ -248,7 +248,7 @@ ein Array sein mit zwei Zahlen: `$wh = [ 0 => «bildbreite», 1 => «bildhöhe»
 Die Funktion ist "static" deklariert und kann auch außerhalb des Klassen-Kontext aufgerufen werden.
 
 ```php
-use FriendsOfREDAXO\focuspoint\rex_effect_abstract_focuspoint;
+use FriendsOfRedaxo\focuspoint\rex_effect_abstract_focuspoint;
 
 $fp1 = rex_effect_abstract_focuspoint::str2fp( '50,60');                 // Ergebnis: false
 $fp1 = rex_effect_abstract_focuspoint::str2fp( '50.0,60.0');             // Ergebnis: [50,60]
@@ -417,7 +417,7 @@ Eine neue Effekt-Klasse sollte drei Methoden bereitstellen:
 Eine rudimentäre Effekt-Klasse würde so aussehen:
 
 ```php
-use FriendsOfREDAXO\focuspoint\rex_effect_abstract_focuspoint;
+use FriendsOfRedaxo\focuspoint\rex_effect_abstract_focuspoint;
 
 class rex_effect_focuspoint_myeffect extends rex_effect_abstract_focuspoint
 {

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -18,6 +18,21 @@
 > - [rex_api_call `focuspoint`](#api-racf)
 > - [Eigene Fokuspunkt-Effekte entwickeln](#api-mofe)
 
+Die Klassen sind mit Aussnahme von `rex_api_focuspoint` im Namensraum `FriendsOfREDAXO\focuspoint\`. Sie
+können entweder über einen vollständigen Qualifier aufgerufen werden oder durch Einbinden am Anfang des Scriptes.
+
+```
+...
+$image = FriendsOfREDAXO\focuspoint\focuspoint_media::get($filename);
+```
+
+```
+use FriendsOfREDAXO\focuspoint\focuspoint_media;
+...
+$image = focuspoint_media::get($filename);
+```
+
+
 <a name="api-ep"></a>
 ## Extension-Point **FOCUSPOINT_PREVIEW_SELECT**
 
@@ -108,6 +123,8 @@ eines Addons wird der Extension-Point `MEDIA_LIST_FUNCTIONS` belegt.
 Abgefragt wird das Default-Feld "med_focuspoint":
 
 ```php
+use FriendsOfREDAXO\focuspoint\focuspoint_media;
+
 if( rex_request('page', 'string') == 'mediapool/media' && !rex_request('file_id', 'string') )
 {
     rex_extension::register( 'MEDIA_LIST_FUNCTIONS', function( rex_extension_point $ep )
@@ -126,6 +143,8 @@ Falls zusätzlich individuelle Fokuspunkt-Metafelder definiert sind, kann mit di
 komplette Satz überprüft werden:
 
 ```php
+use FriendsOfREDAXO\focuspoint\focuspoint_media;
+
 if( rex_request('page', 'string') == 'mediapool/media' && !rex_request('file_id', 'string') )
 {
     rex_extension::register( 'MEDIA_LIST_FUNCTIONS', function( rex_extension_point $ep )
@@ -166,6 +185,8 @@ zurückgegriffen, sondern der Fallback-Wert herangezogen.
 Die Klasse `focuspoint_media` kann z.B. in eigenen Effekten, die auf Fokuspunkten basieren,
 eingesetzt werden, aber auch in beliebigen anderen Zusammenhängen. Hier ein Beispiel :
 ```php
+use FriendsOfREDAXO\focuspoint\focuspoint_media;
+
 $fpMedia = focuspoint_media::get( $filename );
 
 if ( $fpMedia )
@@ -227,6 +248,8 @@ ein Array sein mit zwei Zahlen: `$wh = [ 0 => «bildbreite», 1 => «bildhöhe»
 Die Funktion ist "static" deklariert und kann auch außerhalb des Klassen-Kontext aufgerufen werden.
 
 ```php
+use FriendsOfREDAXO\focuspoint\rex_effect_abstract_focuspoint;
+
 $fp1 = rex_effect_abstract_focuspoint::str2fp( '50,60');                 // Ergebnis: false
 $fp1 = rex_effect_abstract_focuspoint::str2fp( '50.0,60.0');             // Ergebnis: [50,60]
 
@@ -394,6 +417,8 @@ Eine neue Effekt-Klasse sollte drei Methoden bereitstellen:
 Eine rudimentäre Effekt-Klasse würde so aussehen:
 
 ```php
+use FriendsOfREDAXO\focuspoint\rex_effect_abstract_focuspoint;
+
 class rex_effect_focuspoint_myeffect extends rex_effect_abstract_focuspoint
 {
     function getName()

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -123,7 +123,7 @@ eines Addons wird der Extension-Point `MEDIA_LIST_FUNCTIONS` belegt.
 Abgefragt wird das Default-Feld "med_focuspoint":
 
 ```php
-use FriendsOfREDAXO\FriendsOfRedaxo\focuspoint_media;
+use FriendsOfRedaxo\focuspoint\focuspoint_media;
 
 if( rex_request('page', 'string') == 'mediapool/media' && !rex_request('file_id', 'string') )
 {
@@ -143,7 +143,7 @@ Falls zusätzlich individuelle Fokuspunkt-Metafelder definiert sind, kann mit di
 komplette Satz überprüft werden:
 
 ```php
-use FriendsOfREDAXO\FriendsOfRedaxo\focuspoint_media;
+use FriendsOfRedaxo\focuspoint\focuspoint_media;
 
 if( rex_request('page', 'string') == 'mediapool/media' && !rex_request('file_id', 'string') )
 {
@@ -218,6 +218,9 @@ abgeleitet werden. Das AddOn basiert darauf, dass Fokuspunkt-Effekte von der Kla
 `rex_effect_abstract_focuspoint` abstammen und die darin bereitgestellten Parameter-Felder
 (`meta`, `focus`) aufweisen.
 
+> **Bitte beachten:** Mediamanager-Effekte werden READXO-intern über den Klassennamen `rex_effect_....` gesucht.
+Effekte dürfen nicht in einem Namespace wie `FriendsOfRedaxo\focuspoint` liegen. 
+
 Es stehen sechs Methoden zur Verfügung:
 
 - `str2fp` wandelt einen Koordinaten-String in ein Koordinaten-Wertepaar um oder liefert false
@@ -248,8 +251,6 @@ ein Array sein mit zwei Zahlen: `$wh = [ 0 => «bildbreite», 1 => «bildhöhe»
 Die Funktion ist "static" deklariert und kann auch außerhalb des Klassen-Kontext aufgerufen werden.
 
 ```php
-use FriendsOfRedaxo\focuspoint\rex_effect_abstract_focuspoint;
-
 $fp1 = rex_effect_abstract_focuspoint::str2fp( '50,60');                 // Ergebnis: false
 $fp1 = rex_effect_abstract_focuspoint::str2fp( '50.0,60.0');             // Ergebnis: [50,60]
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,475 +1,93 @@
-> - Installation und Einstellungen
->   - Installation
->   - [Einstellungen](settings.md)
-> - [Kartensätze verwalten](mapset.md)
-> - [Karten/Layer verwalten](layer.md)
-> - [Karten-Proxy und -Cache](proxy_cache.md)
-> - [Für Entwickler](devphp.md)
->   - [PHP](devphp.md)
->   - [Javascript](devjs.md)
->   - [JS-Tools](devtools.md)
->   - [geoJSON](devgeojson.md)
->   - [Rechnen (PHP)](devmath.md)
-
-# Installation und Systemkonfiguration
-
-## Inhalt
-
-Die Installation erfolgt wie gewohnt im Backend der READXO-Instanz. Neben der Basisinstallation
-gibt es eine individualisierte Installation.
-
-- [Installation](#install)
-- [Individualisierte Installation](#custom)
-    - [Systemparameter anpassen (*config.yml*)](#parameter)
-    - [Karten und Kartensätze vorbefüllen](#dataset)
-    - [Installation als Proxy/Cache](#proxy)
-    - [Eigene Scripte und CSS-Formatierungen](#ownjscss)
-    - [LeafletJS ohne **Geolocation**](#compile1)
-    - [**Geolocation** ohne LeafletJS](#compile0)
-- [Berechtigungen](#perm)
-
-<a name="install"></a>
-## Installation
-
-**Geolocation** ist nicht über den REDAXO-Installer verfügbar. Das
-[Repository](https://github.com/christophboecker/geolocation/) muss bei GitHub
-[als ZIP-Archiv heruntergeladen](https://github.com/christophboecker/geolocation/archive/master.zip)
-und im Addon-Verzeichnis der RREDAXO-Instanz in den Ordner *src/addons/geolocation* entpackt werden.
-
-In der Addon-Verwaltung der REDAXO-Instanz kann das Addon nun installiert werden.
-
-Die Installation (I) bzw. Re-Installation (R) umfasst folgende Schritte
-
-- Tabellen *rex_geolocation_mapset* und *rex_geolocation_layer* anlegen (I) bzw. bei angelegten
-  Tabellen die notwendigen Felder sicherstellen (R).
-- Wenn beide Tabellen leer sind, wird ein Demo-Datensatz installiert (I|R).
-- Die Tabellen werden über YForm verwaltet. Die dazu nötigen Tablesets werden installiert (I) bzw.
-  angepasst (R).
-- Sofern es keinen Cron-Job "Geolocation: Cleanup Cache" gibt, wird er angelegt. Ein vorhandener Job
-  wird nicht verändert, ist also update-sicher (I|R).
-- Ein Teil der im Betrieb notwendigen Parameter werden in die Konfigurationstabelle *rex_config* im
-  Namespace "geolocation" eingetragen bzw. fehlende werden ergänzt (I|R).
-- Ein Teil der im Betrieb notwendigen Parameter werden als Konstanten in die *boot.php* eingetragen.
-- JS- und CSS-Dateien aus dem Asset-Verzeichnis des Addons werden in das öffentliche
-  Assets-Verzeichnis des addons kopiert
-- Die **Geolocation**-spezifischen JS- und CSS-Dateien werden neu in das öffentliche
-  Assets-Verzeichnis kompiliert (I|R).
-
-<a name="custom"></a>
-## Individualisierte Installation
-
-Die Installation basiert auf den Dateien im Verzeichnis *src/addons/geolocation/install*. Über
-ein weiteres Verzeichnis *data/addons/geolocation/* kann die Installation und bis zu einem gewissen
-Grad auch die Re-Installaion individualisiert werden.
-
-| Datei | Verwendung | Anmerkung |
-|-|-|-|
-| config.yml | Die Grundeinstellungen des **Geolocation**-Addons wie Standard-Kartenausschnitt, Job-Parameter, Ausgabefragment | Überschreibt die angegebenen gleichnamigen Werte in der Originaldatei |
-| dataset.sql | SQL-Statements zur Erstbefüllung der Tabellen | *rex_geoocation_mapset*<br>*rex_geolocation_layer* |
-| geolocation.css | Zusätzliche CSS-Einstellungen, gedacht für zusätzliche Leaflet-Plugins bzw. Leaflet-Erweiterungen, eigene Erweiterungen und Anpassungen an die REDAXO-Instanz | [Eigene Scripte und CSS-Formatierungen](#ownjscss) |
-|geolocation.js | Zusätzliche JS-Scripte, gedacht für zusätzliche Leaflet-Plugins bzw.Leaflet-Erweiterungen und individuelle JS-Geolocation-Erweiterungen  | [Eigene Scripte und CSS-Formatierungen](#ownjscss) |
-| load_assets.php | Multifile-Erweiterungen als Alternative zu den beiden vorgenannten Einzeldateien | [Eigene Scripte und CSS-Formatierungen](#ownjscss) |
-| lang_js | Equivalient zu den lang-Dateien mit Texten, die im JS benutzt werden |  |
-
-Das angegebene Verzeichnis ist update-sicher, da es bei einer De-Installation nicht gelöscht wird.
-Bereits vor der ersten Installation können hier die individuellen Einstellungen platziert werden.
-
-<a name="parameter"></a>
-### Systemparameter anpassen (`config.yml`)
-
-Wie oben beschrieben wird die Grundkonfiguration über die Dateien
-- `data/addons/geolocation/config.yml`
-- `src/addons/geolocation/install/config.yml`
-
-vorgenommen. Die erstgenannte Datei überschreibt die Werte der zweiten; darüber können update-sicher
-eigene Grundeinstellungen konserviert werden. Teilweise sind die Parameter auch über die
-[Einstellungen](settings.md) änderbar. Diese Änderungen bleiben bei einer Re-Installation
-erhalten, werden aber bei einer De-Installation gelöscht.
-
-Änderungen der Parameter sind mit Vorsicht durchzuführen! Die Daten werden weder auf formale
-logische Richtigkeit noch auf Vollständigkeit geprüft.
-
-`src/addons/geolocation/install/config.yml`:
-
-```yml
-# Basiskonfiguration, diverse Konstanten
-#
-# Wird bei der Installation benutzt und u.a. teilweise in die boot.php eingetragen als
-# define('ABC',wert); (ABC im Namespace Geolocation )
-#
-# Überschreiben durch korrespondierende Werte aus redaxo/data/addons/geolocation/config.yml
-# Handle with care!
-
-# Leistungsumfang (alles: full, nur Proxy/Cache: proxy)
-#   mapset          false = Formulare des Addon auf Proxy/Cache einschränken
-#   compile         0 = kein Leaflet und geolocation-JS in geolocation.min.js/css einfügen
-#                   1 = Leaflet-Core, sonst keine eigenen Elemente; danach aus data
-#                   2 = Leaflet und geolocation-JS; danach aus data
-#   load            false =geolocation.min.js, geolocation.man.css nicht laden
-scope:
-    mapset: true
-    compile: 2
-    load: true
-
-# Karten und Kartensätze aus  "dataset.sql" vorbelegen
-dataset:
-    load: true
-    overwrite : false
-
-# Time-To-Live im Karten-Cache
-Geolocation\TTL_DEF: 10080
-Geolocation\TTL_MIN: 0
-Geolocation\TTL_MAX: 130000
-
-# Maximale Anzahl Dateien pro Karten-Cache
-Geolocation\CFM_DEF: 1000
-Geolocation\CFM_MIN: 50
-Geolocation\CFM_MAX: 100000
-
-# URL-Name für API-Abrufe
-Geolocation\KEY_TILES: 'geolayer'
-Geolocation\KEY_MAPSET: 'geomapset'
-
-# Fragment zur Kartenausgabe
-Geolocation\OUT: 'geolocation_rex_map.php'
-
-# Darstellungsoptionen
-# true = mapset::mapoptions, sonst '|xxx|yyy|' mit den Keys aus mapset::mapoptions
-mapoptions: true
-
-# Anzuzeigender Default-Kartenausschnitt = Europa (für Tool "bounds")
-bounds: '[35,-9],[60,25]'
-
-# Standard-Zoom
-zoom: 15
-zoom_min: 2
-zoom_max: 18
-
-# Aufrufintervall für den Aufräum-Job des Cache
-# und weitere Parameter
-job_moment: 0
-job_environment: '|frontend|backend|'
-job_intervall:
-    minutes:
-        0: '30'
-    hours:
-        0: '05'
-    days: 'all'
-    weekdays: 'all'
-    months: 'all'
-```
-
-Anwendungsbeispiel: In der Konfiguration ist als Standard-Kartenausschnitt "Europa" festgelegt. Das
-kann über die Einstellungen, aber auch als update-sichere Vorbelegung z.B. auf D-A-CH geändert
-werden:
-
-`data/addons/geolocation/config.yml`:
-
-```yml
-# Anzuzeigender Default-Kartenausschnitt (Tool "bounds"): D-A-CH
-bounds: '[46,5.5],[55,17]'
-```
-
-Die mit `Geolocation\` beginnenden Einträge werden unter dem angegebenen Namen als Konstanten in die
-`boot.php` geschrieben. `bounds` und `zoom` werden auch in die JS-Datei `geolocation.min.js`
-übernommen.
-
-Der Scope `mapset: false` **ist mit Vorsicht zu nutzen**. Darüber kann die Verwaltungsseite von
-Geolocation verändert werden. Alle Bereich betreffend Kartensätze werden ausgeblendet. Das ist
-sinnvoll wenn **Geolocation** nur als Proxy/Cache genutzt wird. Die Verifizierungs-Regeln für
-Formulare und Tabellen sind damit nicht aufgehoben! Angenommen es gibt Kartensätze, bei denen
-Karteneinträge zugewiesen sind. Der Scope `mapset: false` blendet den Menüpunkt "Kartensatz" aus.
-Die verknüpften Karten können nicht mehr gelöscht werden, da sie im Kartensatz eingebunden sind.
-Soll nur die vereinfachte Proxy-Ansicht genutzt werden, sollte eine
-[Installation mit angepasstem Datensatz](#proxy) erfolgen.
-
-Um im Bedarfsfall selbst die konsolidierte Liste aller Konfigurationsparameter einzulesen, müssen
-beide Dateien eingelesen und verbunden werden.
-```php
-$config = array_merge(
-    \rex_file::getConfig( \rex_path::addonData(\Geolocation\ADDON,'config.yml'), [] ),
-    \rex_file::getConfig( \rex_path::addon(\Geolocation\ADDON,'install/config.yml'), [] ),
-);
-```
-
-<a name="dataset"></a>
-### Karten und Kartensätze vorbefüllen
-
-Wie oben beschrieben wird die Anpassung über die Dateien
-- `data/addons/geolocation/config.yml`
-- `data/addons/geolocation/dataset.sql`
-
-durchgeführt.
-
-#### Tabellen überschreiben
-
-In der Basiseinstellung wird die Datei `dataset.sql` importiert, wenn _beide_ Tabellen leer sind.
-(`overwrite: false`). Das verhindert versehentliches Überschreiben bei einer Re-Installation. Wenn
-per `load: false` ohnehin kein Ladeprozess gestartet wird, hat `overwrite` keine Auswirkung.
-
-```yml
-# Karten und Kartensätze aus  "dataset.sql" vorbelegen
-dataset:
-    load: true
-    overwrite: true
-```
-
-Um auf jeden Fall `dataset.sql` auszuführen, müssen beide Werte auf `true` stehen.
-
-#### Tabellen nicht vorbefüllen
-
-Über den Parameter in der `config.yml` wird der Ladevorgang unterbunden. Vorhandene Datensätze
-bleiben erhalten.
-
-```yml
-# Karten und Kartensätze aus  "dataset.sql" vorbelegen
-dataset:
-    load: false
-```
-
-#### Eigene Kartendaten und Kartensätze
-
-Im Normalfall werden bei der Installation (beide Tabellen leer) Beispieldaten geladen. Werden eigene
-Einstellungen gewünscht, kann eine entsprechende `dataset.sql` z.B. als Datenbank-Export hinterlegt
-werden. Die Tabellennamen werden von der Installationsroutine an das eingestellte Prefix der Instanz
-angepasst (tausche `rex_` gegen das eingestellte Prefix).
-
-```sql
---
--- Daten für Tabelle `rex_geolocation_layer`
---
-TRUNCATE TABLE `rex_geolocation_layer`;
-INSERT INTO `rex_geolocation_layer` (`id`, `name`, `url`, `subdomain`, `attribution`, `lang`, `layertype`, `ttl`, `cfmax`, `online`) VALUES
-(...),
-...;
-
---
--- Daten für Tabelle `rex_geolocation_mapset`
---
-TRUNCATE TABLE `rex_geolocation_mapset`;
-INSERT INTO `rex_geolocation_mapset` (`id`, `name`, `title`, `layer`, `overlay`, `mapoptions`, `outfragment`) VALUES
-(...),
-...;
-```
-
-<a name="proxy"></a>
-### Installation als Proxy/Cache
-
-Wie oben beschrieben wird die Anpassung über die Dateien
-- `data/addons/geolocation/config.yml`
-- `data/addons/geolocation/dataset.sql`
-
-durchgeführt. In der Konfiguration `config.yml` wird der Betriebsumfang auf `mapset: false`
-geändert. Anschließend sollte eine Re-Installation erfolgen oder noch besser eine Neu-Installation,
-damit auch die Datenbank neu aufgebaut wird.
-
-`data/addons/geolocation/config.yml`:
-```yml
-# Leistungsumfang
-scope:
-    mapset: false
-    compile: 0
-    load: false
-```
-
-Im reinen Proxy-Mode sind die Asset-Dateien zum Kartenaufbau nicht erforderlich bzw. werden
-außerhalb des Addons erwartet. Daher ist es weder notwendig, die Asset-Dateien aufzubauen
-(`compile: 0`), noch die Asset-Dateien im Frontend bzw. Backend zu laden (`load: false`).
-
-Für eine Variante mit dennoch geladenem Leaflet, ober ohne Geolocation-Tools, siehe [unten](#compile1).
-
-Die Tabellen können bzw. sollten leer bleiben.
-
-`data/addons/geolocation/dataset.sql`:
-```sql
---
--- Daten für Tabelle `rex_geolocation_layer`
---
-TRUNCATE TABLE `rex_geolocation_layer`;
-INSERT INTO `rex_geolocation_layer` (`id`, `name`, `url`, `subdomain`, `attribution`, `lang`, `layertype`, `ttl`, `cfmax`, `online`) VALUES
-(...),
-...;
-
---
--- Daten für Tabelle `rex_geolocation_mapset` im reinen Proxy-Mode irrelevant; sollte leer sein.
---
-TRUNCATE TABLE `rex_geolocation_mapset`;
-```
-
-<a name="ownjscss"></a>
-### Eigene Scripte und CSS-Formatierungen einbinden
-
-Spätestens wenn die Leaflet-Karte um zusätzliche Plugins und/oder passende individuelle Tools
-erweitert werden, stellt sich die Frage, wie sie im System einzubinden sind. In der klassischen
-Variante werden die JS- und CSS-Dateien separat und zeitlich nach den **Geolocation**-Dateien in FE
-und BE eingebunden.
-
-**Geolocation** bietet alternativ die Möglichkeit, die zusätzlichen Komponenten minifiziert bzw.
-komprimiert direkt in die **Geolocation**-Assets einzubinden. Bei jeder (Re-)Installation
-bzw. beim Speichern der [Einstellungen](settings.md) werden die Asset-Dateien
-
-- `/assets/addons/geolocation/geolocation.css`  
-- `/assets/addons/geolocation/geolocation.js`  
-- `/assets/addons/geolocation/geolocation_be.css`  
-
-neu erzeugt. Dabei werden im Verzeichnis `data/addons/geolocation/` liegende gleichnamige Dateien
-nach den Standardkomponenten eingefügt. Solange es sich um relativ einfachen bzw. ohnehin
-individuell geschriebenen Code in jeweils einer Datei handelt, ist das Verfahren gut handhabbar.
-
-Mittels der Utility [AssetPacker](https://github.com/christophboecker/AssetPacker) (siehe
-lib-Verzeichnis) werden die Komponenten zusammengeführt und komprimiert. Der Code findet sich
-in der Datei `lib/config_form.php`.
-
-```php
-// Assets neu kompilieren
-\Geolocation\config_form::compileAssets();
-```
-
-Komplexere Erweiterungen z.B. aus mehreren Leaflet-Plugins setzen voraus, dass die infrage kommenden
-Dateien zunächst zu einer einzigen Datei (`geolocation.css`, `geolocation.js`) zusammengefasst
-sind. Alternativ kann eine Script-Datei `load_assets.php` bereitgestellt werden. Die
-AssetPacker-Instanzen der drei Zieldateien sind im Script verfügbar.
-
-```
-array:6 [▼
-    "addonDir" => "«path_to_redaxo»/redaxo/src/addons/geolocation/"
-    "dataDir" => "«path_to_redaxo»/redaxo/data/addons/geolocation/"
-    "assetDir" => "«path_to_redaxo»/assets/addons/geolocation/"
-    "css" => Geolocation\AssetPacker\AssetPacker_css {#270 ▶}
-    "js" => Geolocation\AssetPacker\AssetPacker_js {#271 ▶}
-    "be_css" => Geolocation\AssetPacker\AssetPacker_css {#272 ▶}
-]
-```
-
-Systemseitig werden zuerst die Komponenten von LeafletJS und die im Addon benutzten Plugins
-eingebaut, dann der Code von **Geolocation** (Karten aufbauen). Hier eine vereinfacht Darstellung
-des Ablaufs in `compileAssets`:
-
-```php
-$css = AssetPacker\AssetPacker::target( $assetDir.'geolocation.min.css')
-    ->overwrite()
-    ->addFile( $addonDir.'install/vendor/leaflet/leaflet.css') )
-    ->addFile( $addonDir.'install/vendor/Leaflet.GestureHandling/leaflet-gesture-handling.min.css') )
-    ->addFile( $addonDir.'install/geolocation.css') );
-$js = AssetPacker\AssetPacker::target( $assetDir.'geolocation.min.js')
-    ->overwrite()
-    ->addFile( $addonDir.'install/vendor/leaflet/leaflet.js') )
-    ->addFile( $addonDir.'install/vendor/Leaflet.GestureHandling/leaflet-gesture-handling.min.js') )
-    ->addFile( $addonDir.'install/geolocation.js') );
-
-$be_css = AssetPacker\AssetPacker::target( $assetDir.'geolocation_be.min.css')
-    ->overwrite()
-    ->addFile( $addonDir.'install/geolocation_be.css' );
-
-if( is_file($dataDir.'load_assets.php') ) {
-    include $dataDir.'load_assets.php';
-} else {
-    $css->addOptionalFile( $dataDir.'geolocation.css');
-    $js->addOptionalFile( $dataDir.'geolocation.js');
-    $be_css->addOptionalFile( $dataDir.'geolocation_be.css');
-}
-
-$css->create();
-$js->create();
-$be_css->create();
-```
-
-Wie Dateien hinzugefügt werden, beschreibt als Beispiel der Code in `compileAssets()` und darüber
-hinaus das [Handbuch zu AssetPacker](https://github.com/christophboecker/AssetPacker/blob/main/README.md).
-Hier ein schematisches Beispiel für eine `load_config.php`:
-
-```php
-// Asset-Dateien für Leaflet erweitern
-$dir = \rex_path::addonData(\Geolocation\ADDON);
-$js
-    ->addFile( $dir.'/vendor/plugin_x/plugin_x.min.js')
-    ->regReplace( '%//#\s+sourceMappingURL=.*?$%im','//' )
-    ->addFile( $dir.'/vendor/plugin_y/plugin_y.js')
-    ->regReplace( '%//#\s+sourceMappingURL=.*?$%im','//' )
-    ->addFile( $dir.'/mytools.js');
-$css
-    ->addFile( $dir.'/vendor/plugin_x/plugin_x.min.css')
-    ->addFile( $dir.'/vendor/plugin_x/plugin_y.css')
-    ->addFile( $dir.'/mytools.css');
-```
-
-Außer beim Installieren bzw. Re-Installieren werden die Asset-Dateien bei Änderungen der
-[Einstellungen](settings.md) neu kompiliert. Daher ist für Änderungen der Asset-Dateien keine
-(Re-)Installation erforderlich; speichern der Einstellungen reicht aus.
-
-<a name="compile1"></a>
-### LeafletJS ohne **Geolocation**  
-
-Auch in der Betriebsart "Proxy/Cache" benötigt man eine Kartensoftware á la LeafletJS und ein wenig
-Javascript, um darauf aufbauend die Karte anzuzeigen. Über Installationsparameter Erweiterungen
-können die Asset-Dateien entsprechend konfiguriert und geladen werden. Die Anpassung erfolgt wie
-oben beschrieben über die Dateien
-- `data/addons/geolocation/config.yml`
-- `data/addons/geolocation/geolocation.js`
-- `data/addons/geolocation/geolocation.css`
-- `data/addons/geolocation/load_assets.php`
-
-Die Schritte:
-
-1. Über `config.yml` wird der automatisch generierte Umfang der JS/CSS-Dateien auf LeafletJS
-   begrenzt. Eigener Code von **Geolocation** und dafür notwendige Leaflet-Erweiterungen werden
-   nicht geladen.
-   ```yml
-   scope:
-       mapset: false
-       compile: 1
-       load: true
-   ```
-2. Mit den übrigen drei Dateien wird wie [zuvor](#ownjscss) beschrieben der Kern um eigene Elemente
-   erweitert (weitere Leaflet-Plugins, eigener Code zur Karten-Generierung).
-3. Der Vollständigkeit halber sei darauf hingewiesen, dass wesentliche PHP-Teile von **Geolocation**
-   für die Kartenausgabe auch durchaus in diesem Setup funktionieren können. Z.B. kann in dem Fall
-   ein alternatives Ausgabefragment eingesetzt werden, wenn die Karten auf dem HERE-JS aufsetzen
-   (oder Google oder Apple oder ...)
-   ```yml
-   Geolocation\OUT: 'my_nice_own_map_fragment.php'
-   ```
-
-<a name="compile0"></a>
-### **Geolocation** ohne LeafletJS
-
-**Geolocation** kann gänzlich ohne LeafletJS genutzt werden. [Zuvor](#compile1) wurde bereits die
-grundlegende Vorgehensweise beschrieben, über das data-Verzeichnis eigenes JS zu laden.
-
-Zusätzlich zu eigenem Anwendungscode muss in diesem Setup auch die Kartensoftware selbst geladen
-werden, während LeafletJS außen vor bleibt.
-
-Beim Neu-Compilieren der Asset-Dateien muss in der `config.yml` eingetragen sein:
-
-```yml
-scope:
-    mapset: true # oder false
-    compile: 0
-    load: true
-```
-
-<a name="perm"></a>
-## Berechtigungen
-
-Die Berechtigungsverwaltung erfolgt über die Benutzer- und Rollenverwaltung in REDAXO.
-
-| Rolle | Beschreibung |
-|-|-|
-|admin| Darf alles, sieht alles|
-|geolocation[mapset]|Kartensätze zusammenstellen und verwalten|
-|geolocation[layer]|Kartendaten / Layer-Daten bearbeiten. Da hier die grundlegende Funktion schnellbeeinträchtigt werden kann (z.B. falsche URLs), sollte diese Berechtigung ohnehin Entwicklern und Admins vorbehalten sein.|
-|geolocation[clearcache]|Cache löschen; Das Recht bezieht sich auf per `rex_api` ausgelöstes Löschen (z.B. Lösch-Button der Addon-Seiten im Backend). Cronjobs sind nicht betroffen|
-
-Passend dazu werden auch die Handbuchseiten eingeschränkt. Diese Installationsseite ist z.B. nur für
-Admins sichtbar.
-
-## Darkmode
-
-Das Addon berücksichtigt im Grunde die Darkmode-Einstellung der Redaxo-Instanz. Die Darstellung im
-Backend erfolgt mit dem Standard-CSS. Eine Einschränkung gilt für die Leaflet-Karten. LeafletJS
-unterstützt generisch keinen Darkmode.
-
-Es gibt Plugins für LeafletJS, die auch eine Darkmode-Darstellung ermöglichen sollen. Vor einer
-Integration in **Geolocation** wären mit Sicherheit ausführliche Kompatibilitätstests und ggf.
-weitere Anpassungen erforderlich. Ob sich der Aufwand lohnt, sei dahingestellt, denn auch die Karten
-müssen Darkmode-Karten sein. Liefert der Anbieter solche Tiles?  
+> - [Grundlagen](#overview)
+> - [Bildern Fokuspunkte zuweisen](edit.md)
+> - [Media-Manager: der Effekt "focuspoint-fit"](media_manager.md)
+> - Addon-Verwaltung
+> - [Hinweise für Entwickler (API)](developer.md)
+
+# Addon-Verwaltung
+
+<a name="manage-install"></a>
+## Installieren
+
+Die Installation umfasst:
+
+* Metafeldtyp `Focuspoint (AddOn)` anlegen
+* Metafeld `med_focuspoint` vom Typ `Focuspoint (AddOn)` anlegen
+* Media-Manager-Typ `focuspoint_media_detail` anlegen
+* Verzeichnis `/assets/addons/focuspoint` anlegen und befüllen
+
+Anschließend stehen alle Funktionalitäten wie in diesem Dokument beschrieben zur Verfügung.
+
+Sollte es bereits einen Metafeldtyp `Focuspoint (AddOn)` geben, wird dessen `type_id` benutzt.
+
+Sollte es bereits ein Meta-Feld `med_focuspoint` geben, das einen anderen Feldtyp hat, wird die
+Installation abgebrochen. Das Feld muss zuerst gelöscht oder umbenannt werden.
+
+Sollte es bereits einen Media-Manager-Typ `focuspoint_media_detail` geben, wird lediglich der
+damit verbundene Effekt reinitialisiert.
+
+<a name="manage-reinstall"></a>
+## Re-Installieren
+
+REDAXO nutzt für die Re-Installation dieselbe Routine wie für die Installation. Zwischenzeitliche Änderungen (z.B. im Assets-Verzeichnis) werden zurückgedreht.
+
+Existierende Fokuspunkt-Metafelder (Typ `Focuspoint (AddOn)`) bleiben unangetastet.
+
+<a name="manage-activate"></a>
+## Aktivieren
+
+Aktivierung hebt eine Deaktivierung auf. Dabei wird überprüft, ob zwischenzeitlich gravierende
+Änderungen vorgenommen wurden:
+
+- Metafeldtyp `Focuspoint (AddOn)` entfernt
+- Metafeld `med_focuspoint` vom Typ `Focuspoint (AddOn)` entfernt
+- Media-Manager-Typ `focuspoint_media_detail` entfernt
+
+In diesen Fällen kommt ein Warnhinweis, die Aktivierung unterbleibt und eine [Re-Installation](#manage-reinstall)
+ist notwendig.
+
+<a name="manage-deactivate"></a>
+## De-Aktivieren
+
+> **Durch De-Aktivieren des Addons wird Media-Manager-Typen, die die mitgelieferten Effekte bzw.
+auf der Klasse `rex_effect_abstract_focuspoint` basierende Effekte nutzen, die Grundlage entzogen!**
+
+Vor dem De-Aktivieren wird überprüft ob im Media-Manager Typen eingerichtet sind, die auf der
+Klasse `rex_effect_abstract_focuspoint` basierende Effekte nutzen. Wenn ja, wird der Vorgang
+abgebrochen.
+
+Die Metafelder für Fokuspunkte (Typ `Focuspoint (AddOn)`) bleiben erhalten, auch wenn sie im Detailformular
+für Medien nicht mehr angezeigt werden.
+
+Es wird **nicht** überprüft, **ob** es eigenentwickelte, aber nicht eingesetzte Effekte in anderen AddOns gibt, die auf der Klasse
+`rex_effect_abstract_focuspoint` basieren. Diese Abhängigkeit muss durch das andere AddOn über dessen
+Konfiguration (`package.yml`, Abschnitt `requires:`) beschrieben werden.
+
+<a name="manage-uninstall"></a>
+## De-Installieren
+
+> **Durch De-Installation des Metafeldtyps `Focuspoint (AddOn)` wird allen darauf basierenden
+Meta-Feldern die Basis entzogen!**
+
+> **Durch De-Aktivieren des Addons wird Media-Manager-Typen, die die mitgelieferten Effekte bzw.
+auf der Klasse `rex_effect_abstract_focuspoint` basierende Effekte nutzen, die Grundlage entzogen!**
+
+Vor der De-Installaton werden die Abhängigkeiten überprüft und der Vorgang ggf. abgebrochen und zur
+Beseitigung der Konflikte aufgefordert.
+
+Die eigentliche De-Installation umfasst:
+
+* Media-Manager-Typ `focuspoint_media_detail` löschen
+* Metafeld `med_focuspoint` entfernen
+* Metafeldtyp `Focuspoint (AddOn)` entfernen
+* Verzeichnis `/assets/addons/focuspoint` löschen
+
+Es wird **nicht** überprüft, **ob** es eigenentwickelte Effekte in anderen AddOns gibt, die auf der Klasse
+`rex_effect_abstract_focuspoint` basieren. Diese Abhängigkeit muss durch das andere AddOn über dessen
+Konfiguration (`package.yml`, Abschnitt `requires:`) beschrieben werden.
+
+
+<a name="manage-delete"></a>
+## Löschen
+
+Zusätzlich zum [De-Installieren](#manage-uninstall) werden alle AddOn-Dateien gelöscht.

--- a/fragments/fp_metafield.php
+++ b/fragments/fp_metafield.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     2.0
+ *  @version     4.1.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -23,21 +23,27 @@
  *  $this->hidden       true => ausblenden
  */
 
-if( !isset( $this->default ) ) $this->default = '';
+namespace FriendsOfREDAXO\focuspoint;
+
+use rex_fragment;
+
+if (!isset($this->default)) {
+    $this->default = '';
+}
 $feld = new rex_fragment();
 $feld->setVar('elements', [
-        [
-            'class' => 'focuspoint-input-group',
-            'left'  => '<button class="btn btn-default" type="button"><i class="rex-icon fa-crosshairs"></i></button>',
-            'field' => "<input id=\"{$this->id}\" name=\"$this->name\" value=\"$this->value\" pattern=\"^(100|[1-9]?[0-9])[.][0-9],(100|[1-9]?[0-9])[.][0-9]$\" type=\"text\" class=\"form-control\" data-default=\"$this->default\" data-fpinitial=\"$this->value\" />",
-        ]
-    ], false);
+    [
+        'class' => 'focuspoint-input-group',
+        'left' => '<button class="btn btn-default" type="button"><i class="rex-icon fa-crosshairs"></i></button>',
+        'field' => "<input id=\"{$this->id}\" name=\"$this->name\" value=\"$this->value\" pattern=\"^(100|[1-9]?[0-9])[.][0-9],(100|[1-9]?[0-9])[.][0-9]$\" type=\"text\" class=\"form-control\" data-default=\"$this->default\" data-fpinitial=\"$this->value\" />",
+    ],
+], false);
 
 $feld->setVar('elements', [
-        [
-            'label'=>$this->label,
-            'field'=>$feld->parse('core/form/input_group.php'),
-            'class'=>'focuspoint-form-group' . ($this->hidden?' hidden':''),
-        ]
-    ], false);
+    [
+        'label' => $this->label,
+        'field' => $feld->parse('core/form/input_group.php'),
+        'class' => 'focuspoint-form-group' . ($this->hidden ? ' hidden' : ''),
+    ],
+], false);
 echo $feld->parse('core/form/form.php');

--- a/fragments/fp_metafield.php
+++ b/fragments/fp_metafield.php
@@ -23,7 +23,7 @@
  *  $this->hidden       true => ausblenden
  */
 
-namespace FriendsOfREDAXO\focuspoint;
+namespace FriendsOfRedaxo\focuspoint;
 
 use rex_fragment;
 

--- a/fragments/fp_panel.php
+++ b/fragments/fp_panel.php
@@ -22,7 +22,7 @@
  *                                      Dann wird ein Select eingebaut.
  */
 
-namespace FriendsOfREDAXO\focuspoint;
+namespace FriendsOfRedaxo\focuspoint;
 
 use rex_effect_abstract_focuspoint;
 use rex_i18n;

--- a/fragments/fp_panel.php
+++ b/fragments/fp_panel.php
@@ -3,12 +3,11 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     2.2.0
+ *  @version     4.1.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
  *  file that was distributed with this source code.
- *
  *
  *  ------------------------------------------------------------------------------------------------
  *
@@ -22,22 +21,32 @@
  *                                      Fokuspunkt-Metafeld gibt und mindestens eines "hidden" ist
  *                                      Dann wird ein Select eingebaut.
  */
+
+namespace FriendsOfREDAXO\focuspoint;
+
+use rex_effect_abstract_focuspoint;
+use rex_i18n;
+use rex_media;
+use rex_media_manager;
+
 ?>
 <div id="focuspoint-panel" class="focuspoint-panel panel panel-default">
     <div class="panel-heading"><?= rex_i18n::msg('focuspoint_detail_header') ?></div>
 <?php
 $mediatypes = '';
-if( isset( $this->mediatypes ) && is_array( $this->mediatypes ) )
-{
+if (isset($this->mediatypes) && \is_array($this->mediatypes)) {
     $mediatypes = $this->mediatypes;
-    array_walk( $mediatypes, function(&$t, $k) { $t = '<li data-ref="'.$k.'" data-field="'.implode(' ',$t['meta']).'"><a href="#" >'.$t['label'].'</a></li>'; });
-    $mediatypes = implode('',$mediatypes);
+    array_walk($mediatypes, static function (&$t, $k) {
+    $t = '<li data-ref="' . $k . '" data-field="' . implode(' ', $t['meta']) . '"><a href="#" >' . $t['label'] . '</a></li>';
+    });
+    $mediatypes = implode('', $mediatypes);
 }
-if( isset( $this->fieldselect ) && is_array( $this->fieldselect ) )
-{
+if (isset($this->fieldselect) && \is_array($this->fieldselect)) {
     $fieldselect = $this->fieldselect;
-    array_walk( $fieldselect, function(&$v,$k) { $v = "<option value='$k'>$v</option>"; });
-    $fieldselect = implode('',$fieldselect);
+    array_walk($fieldselect, static function (&$v, $k) {
+    $v = "<option value='$k'>$v</option>";
+    });
+    $fieldselect = implode('', $fieldselect);
 ?>
     <div class="input-group focuspoint-panel-select">
         <span class="input-group-addon"><?= rex_i18n::msg('focuspoint_detail_select') ?></span>
@@ -47,7 +56,7 @@ if( isset( $this->fieldselect ) && is_array( $this->fieldselect ) )
 }
 ?>
     <div class="focuspoint-panel-image">
-        <img src="<?= rex_media_manager::getUrl(rex_effect_abstract_focuspoint::MM_TYPE, $this->mediafile, rex_media::get($this->mediafile)->getUpdateDate()); ?>">
+        <img src="<?= rex_media_manager::getUrl(rex_effect_abstract_focuspoint::MM_TYPE, $this->mediafile, rex_media::get($this->mediafile)->getUpdateDate()) ?>">
         <div class="focuspoint-panel-enabler hidden"></div>
     </div>
     <small class="focuspoint-panel-enabler hidden"><span></span></small>
@@ -61,7 +70,7 @@ if( isset( $this->fieldselect ) && is_array( $this->fieldselect ) )
         </div>
         <button type="button" class="btn btn-primary btn-sm" data-button="zoom" ><i class="rex-icon fa-search-plus"></i><i class="rex-icon fa-search-minus"></i></button>
 <?php
-if( $mediatypes ) {
+if ($mediatypes) {
 ?>
         <div class="focuspoint-panel-typeselect btn-group">
             <button type="button" class="btn btn-default  btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><?= rex_i18n::msg('focuspoint_detail_preview') ?> <span class="badge"></span> <span class="caret"></span></button>
@@ -71,7 +80,7 @@ if( $mediatypes ) {
 <?php } ?>
     </div>
 <?php
-if( $mediatypes ) {
+if ($mediatypes) {
 ?>
     <div class="hidden panel-body">
         <img >

--- a/install.php
+++ b/install.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.0.2
+ *  @version     4.1.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -23,8 +23,18 @@
  *  @var rex_addon $this
  */
 
+namespace FriendsOfREDAXO\focuspoint;
+
+use rex;
+use rex_effect_abstract_focuspoint;
+use rex_i18n;
+use rex_metainfo_table_manager;
+use rex_sql;
+
+use function in_array;
+
 // make addon-parameters available
-include_once ( 'lib/effect_focuspoint.php' );
+include_once 'lib/effect_focuspoint.php';
 
 $successMsg = [];
 $message = '';
@@ -52,51 +62,51 @@ $mm_action_effect = false;
 
 // --- Metainfos analysieren -----------------------------------------------------------------------
 
-$qry = 'SELECT a.id,a.type_id,b.id AS tid,b.label AS tlabel FROM '.$db_metafield.' AS a LEFT JOIN '.$db_metatype.' AS b ON a.type_id=b.id WHERE a.name=:name';
-$meta_field = $sql->getArray( $qry, [':name' => rex_effect_abstract_focuspoint::MED_DEFAULT]);
+$qry = 'SELECT a.id,a.type_id,b.id AS tid,b.label AS tlabel FROM ' . $db_metafield . ' AS a LEFT JOIN ' . $db_metatype . ' AS b ON a.type_id=b.id WHERE a.name=:name';
+$meta_field = $sql->getArray($qry, [':name' => rex_effect_abstract_focuspoint::MED_DEFAULT]);
 $meta_field_id = $meta_field ? $meta_field[0]['id'] : null;
 $meta_field_type = $meta_field ? $meta_field[0]['type_id'] : null;
 $meta_field_tid = $meta_field ? $meta_field[0]['tid'] : null;
 $meta_field_tlabel = $meta_field ? $meta_field[0]['tlabel'] : null;
 
 $qry = 'SELECT id FROM ' . $db_metatype . ' WHERE label=:label LIMIT 1';
-$meta_type = $sql->getArray( $qry, [':label' => rex_effect_abstract_focuspoint::META_FIELD_TYPE] );
+$meta_type = $sql->getArray($qry, [':label' => rex_effect_abstract_focuspoint::META_FIELD_TYPE]);
 $meta_type_id = $meta_type ? $meta_type[0]['id'] : null;
 
 // Typ und Feld existieren. Die Typ-ID im Feld entspricht der Metatyp-Id
-if ( $meta_field_id && $meta_type_id && $meta_field_type === $meta_type_id ) {
+if ($meta_field_id && $meta_type_id && $meta_field_type === $meta_type_id) {
     // ok, alles passt zusammen
 }
 
 // Typ und Feld existieren. Die Typ-ID im Feld verweist auf einen anderen Typ
-elseif ( $meta_field_id && $meta_type_id && $meta_field_type === $meta_field_tid ) {
+elseif ($meta_field_id && $meta_type_id && $meta_field_type === $meta_field_tid) {
     // Das Metafeld hat den falschen Typ. Abbruch und Aufforderung zum Aufräumen
     // Abbruch
-    $message = '1 '.rex_i18n::msg( 'focuspoint_install_field_exists', rex_effect_abstract_focuspoint::MED_DEFAULT,rex_effect_abstract_focuspoint::META_FIELD_TYPE );
+    $message = '1 ' . rex_i18n::msg('focuspoint_install_field_exists', rex_effect_abstract_focuspoint::MED_DEFAULT, rex_effect_abstract_focuspoint::META_FIELD_TYPE);
 }
 
 // Typ und Feld existieren. Die Typ-ID im Feld verweist auf einen nicht existenten Typ
-elseif ( $meta_field_id && $meta_type_id && !$meta_field_tid ) {
+elseif ($meta_field_id && $meta_type_id && !$meta_field_tid) {
     // Feld ändern auf meta_type_id
     $meta_action_connect = true;
 }
 
 // nur Typ existiert
-elseif ( $meta_type_id && !$meta_field_tid ) {
+elseif ($meta_type_id && !$meta_field_tid) {
     // Feld auf den Typ anlegen
     $meta_action_field = true;
     $meta_action_connect = true;
 }
 
 // nur Feld existiert und verweist auf einen existenten Typ
-elseif ( $meta_field_id && $meta_field_tid ) {
+elseif ($meta_field_id && $meta_field_tid) {
     // Das Metafeld hat den falschen Typ. Abbruch und Aufforderung zum Aufräumen
     // Abbruch
-    $message = '2 '.rex_i18n::msg( 'focuspoint_install_field_exists', rex_effect_abstract_focuspoint::MED_DEFAULT,rex_effect_abstract_focuspoint::META_FIELD_TYPE );
+    $message = '2 ' . rex_i18n::msg('focuspoint_install_field_exists', rex_effect_abstract_focuspoint::MED_DEFAULT, rex_effect_abstract_focuspoint::META_FIELD_TYPE);
 }
 
 // nur Feld existiert und verweist auf einen nicht existenten Typ
-elseif ( $meta_field_id ) {
+elseif ($meta_field_id) {
     // Typ anlegen und mit dem Feld verbinden
     $meta_action_type = true;
     $meta_action_connect = true;
@@ -110,26 +120,24 @@ else {
 }
 
 // Für das Metafeld besteht die Abhängigkeit zur zugehörigen Spalte in rex_media
-$sql->setQuery('SELECT * FROM '.$db_media.' LIMIT 1');
+$sql->setQuery('SELECT * FROM ' . $db_media . ' LIMIT 1');
 $media_feld = in_array(rex_effect_abstract_focuspoint::MED_DEFAULT, $sql->getFieldnames());
 // Metafeld existiert in rex_metainfo_field, aber die Spalte in rex_media fehlt
-if ( !$meta_action_field && !$media_feld ) {
+if (!$meta_action_field && !$media_feld) {
     $meta_action_media = true;
 }
 // Metafeld existiert nicht in rex_metainfo_field, aber die Spalte in rex_media ist existent
-elseif ( $meta_action_field && $media_feld ){
+elseif ($meta_action_field && $media_feld) {
     // Da die Spalte wichtige Informationen enthalten könnte: Meldung und Abbruch
-    $message = rex_i18n::msg( 'focuspoint_install_media_exists', rex_effect_abstract_focuspoint::MED_DEFAULT,$db_media );
+    $message = rex_i18n::msg('focuspoint_install_media_exists', rex_effect_abstract_focuspoint::MED_DEFAULT, $db_media);
 }
-
 
 // --- Media-Manager-Einträge analysieren ----------------------------------------------------------
 
-$qry = 'SELECT a.id,b.type_id from '.$db_mmtype.' AS a LEFT JOIN '.$db_mmeffect.' AS b ON a.id = b.type_id WHERE a.name=:name LIMIT 1';
-$mm_type = $sql->getArray( $qry, [':name' => rex_effect_abstract_focuspoint::MM_TYPE]);
+$qry = 'SELECT a.id,b.type_id from ' . $db_mmtype . ' AS a LEFT JOIN ' . $db_mmeffect . ' AS b ON a.id = b.type_id WHERE a.name=:name LIMIT 1';
+$mm_type = $sql->getArray($qry, [':name' => rex_effect_abstract_focuspoint::MM_TYPE]);
 $mm_action_type = null === ($mm_type[0]['id'] ?? null);
 $mm_action_effect = null === ($mm_type[0]['type_id'] ?? null);
-
 
 // --- Metainfos anlegen ---------------------------------------------------------------------------
 
@@ -137,77 +145,77 @@ $mm_action_effect = null === ($mm_type[0]['type_id'] ?? null);
 // nicht auftreten. Das Restrisiko einer unvollständigen Installation mit Restanten ist minimal.
 // Fehlende Elemente werden ergänzt
 
-if( $meta_action_type && !$message ) {
+if ($meta_action_type && !$message) {
     $result = rex_metainfo_add_field_type(rex_effect_abstract_focuspoint::META_FIELD_TYPE, 'varchar', 20);
-    if( is_numeric($result) ) {
+    if (is_numeric($result)) {
         $meta_type_id = $result;
         $meta_action_connect = true;
-        $successMsg[] = rex_i18n::msg( 'focuspoint_install_type_ok', rex_effect_abstract_focuspoint::META_FIELD_TYPE );
+        $successMsg[] = rex_i18n::msg('focuspoint_install_type_ok', rex_effect_abstract_focuspoint::META_FIELD_TYPE);
     } else {
-        $message = rex_i18n::rawMsg( 'focuspoint_install_type_error', rex_effect_abstract_focuspoint::META_FIELD_TYPE, "<strong><i>$$result</i></strong>" );
+        $message = rex_i18n::rawMsg('focuspoint_install_type_error', rex_effect_abstract_focuspoint::META_FIELD_TYPE, "<strong><i>$$result</i></strong>");
     }
 }
 
-if( $meta_action_field && !$message ) {
+if ($meta_action_field && !$message) {
     $result = rex_metainfo_add_field('translate:focuspoint_field_label', rex_effect_abstract_focuspoint::MED_DEFAULT, 0, '', $meta_type_id, '', '', '', '');
-    if( true === $result ) {
-        $successMsg[] = rex_i18n::msg( 'focuspoint_install_field_ok', rex_effect_abstract_focuspoint::MED_DEFAULT );
+    if (true === $result) {
+        $successMsg[] = rex_i18n::msg('focuspoint_install_field_ok', rex_effect_abstract_focuspoint::MED_DEFAULT);
         $meta_action_connect = false; // impliziet beim Anlegen durchgeführt
         $meta_action_media = false; // impliziet beim Anlegen durchgeführt
     } else {
-        $message = rex_i18n::rawMsg( 'focuspoint_install_field_error', rex_effect_abstract_focuspoint::MED_DEFAULT, "<strong><i>$result</i></strong>" );
+        $message = rex_i18n::rawMsg('focuspoint_install_field_error', rex_effect_abstract_focuspoint::MED_DEFAULT, "<strong><i>$result</i></strong>");
     }
 }
 
-if( $meta_action_media && !$message ) {
+if ($meta_action_media && !$message) {
     $tableManager = new rex_metainfo_table_manager('rex_media');
-    if ( $tableManager->addColumn(rex_effect_abstract_focuspoint::MED_DEFAULT, 'varchar', 20, '') ) {
-        $successMsg[] = rex_i18n::msg( 'focuspoint_install_media_ok', rex_effect_abstract_focuspoint::MED_DEFAULT, $db_media );
+    if ($tableManager->addColumn(rex_effect_abstract_focuspoint::MED_DEFAULT, 'varchar', 20, '')) {
+        $successMsg[] = rex_i18n::msg('focuspoint_install_media_ok', rex_effect_abstract_focuspoint::MED_DEFAULT, $db_media);
     } else {
-        $message = rex_i18n::rawMsg( 'focuspoint_install_media_error', rex_effect_abstract_focuspoint::MED_DEFAULT, $db_media );
+        $message = rex_i18n::rawMsg('focuspoint_install_media_error', rex_effect_abstract_focuspoint::MED_DEFAULT, $db_media);
     }
 }
 
-if( $meta_action_connect && !$message ) {
-    $sql->setTable( $db_metafield );
-    $sql->setValue( 'type_id', $meta_type_id );
-    $sql->setWhere( 'name=:name', [':name'=>rex_effect_abstract_focuspoint::MED_DEFAULT] );
+if ($meta_action_connect && !$message) {
+    $sql->setTable($db_metafield);
+    $sql->setValue('type_id', $meta_type_id);
+    $sql->setWhere('name=:name', [':name' => rex_effect_abstract_focuspoint::MED_DEFAULT]);
     $sql->update();
-    $successMsg[] = rex_i18n::msg( 'focuspoint_install_link_ok', rex_effect_abstract_focuspoint::META_FIELD_TYPE, rex_effect_abstract_focuspoint::MED_DEFAULT );
+    $successMsg[] = rex_i18n::msg('focuspoint_install_link_ok', rex_effect_abstract_focuspoint::META_FIELD_TYPE, rex_effect_abstract_focuspoint::MED_DEFAULT);
 }
 
 // --- Media-Manager-Einträge anlegen --------------------------------------------------------------
 
-if ( $mm_action_type && !$message ) {
-    $sql->setTable( $db_mmtype );
-    $sql->setValue( 'name', rex_effect_abstract_focuspoint::MM_TYPE );
+if ($mm_action_type && !$message) {
+    $sql->setTable($db_mmtype);
+    $sql->setValue('name', rex_effect_abstract_focuspoint::MM_TYPE);
     $sql->addGlobalCreateFields();
     $sql->addGlobalUpdateFields();
     $sql->insert();
     $mm_type_id = $sql->getLastId();
     $mm_action_effect = true;
-    $successMsg[] = rex_i18n::msg( 'focuspoint_install_mmtype_ok', rex_effect_abstract_focuspoint::MM_TYPE );
+    $successMsg[] = rex_i18n::msg('focuspoint_install_mmtype_ok', rex_effect_abstract_focuspoint::MM_TYPE);
 }
 
-if ( $mm_action_effect && !$message ) {
-    $sql->setTable( $db_mmeffect );
+if ($mm_action_effect && !$message) {
+    $sql->setTable($db_mmeffect);
     // Auch wenn rexstan hier meckert, ist es passed so.
-    // @phpstan-ignore-next-line 
-    $sql->setValue( 'type_id', $mm_type_id );
-    $sql->setValue( 'effect', 'resize' );
-    $sql->setValue( 'parameters', '{"rex_effect_resize":{"rex_effect_resize_width":"1024","rex_effect_resize_height":"1024","rex_effect_resize_style":"maximum","rex_effect_resize_allow_enlarge":"enlarge"}}' );
+    // @phpstan-ignore-next-line
+    $sql->setValue('type_id', $mm_type_id);
+    $sql->setValue('effect', 'resize');
+    $sql->setValue('parameters', '{"rex_effect_resize":{"rex_effect_resize_width":"1024","rex_effect_resize_height":"1024","rex_effect_resize_style":"maximum","rex_effect_resize_allow_enlarge":"enlarge"}}');
     $sql->addGlobalUpdateFields();
     $sql->addGlobalCreateFields();
     $sql->insert();
-    $successMsg[] = rex_i18n::msg( 'focuspoint_install_mmeffect_ok', rex_effect_abstract_focuspoint::MM_TYPE );
+    $successMsg[] = rex_i18n::msg('focuspoint_install_mmeffect_ok', rex_effect_abstract_focuspoint::MM_TYPE);
 }
 
 // Fehlermeldung übertragen; Abbruch
-if( $message ) {
-    $this->setProperty('installmsg', $message );
+if ($message) {
+    $this->setProperty('installmsg', $message);
     return;
 }
 
-if( $successMsg ) {
-    $this->setProperty('successmsg', '<ul><li>'.implode('</li><li>',$successMsg).'</ul>' );
+if ($successMsg) {
+    $this->setProperty('successmsg', '<ul><li>' . implode('</li><li>', $successMsg) . '</ul>');
 }

--- a/install.php
+++ b/install.php
@@ -23,7 +23,7 @@
  *  @var rex_addon $this
  */
 
-namespace FriendsOfREDAXO\focuspoint;
+namespace FriendsOfRedaxo\focuspoint;
 
 use rex;
 use rex_effect_abstract_focuspoint;

--- a/lib/effect_focuspoint.php
+++ b/lib/effect_focuspoint.php
@@ -18,24 +18,23 @@
  *
  *  Eigene Fokuspunkt-Effekte sollten unbedingt hiervon abgeleitet werden, nie direkt von
  *  "rex_effect_abstract"!
- *
  */
 
 abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
 {
-    const URL_KEY = 'xy';
-    const MM_TYPE = 'focuspoint_media_detail';
-    const MED_DEFAULT = 'med_focuspoint';
-    const META_FIELD_TYPE = 'Focuspoint (AddOn)';
-    const HTML_PATTERN = '^(100|[1-9]?[0-9])\.[0-9],(100|[1-9]?[0-9])\.[0-9]$';
-    const PATTERN = '/^(?<x>(100|[1-9]?\d)\.\d),(?<y>(100|[1-9]?\d)\.\d)$/';
-    const STRING = '%3.1F,%3.1F';
+    public const URL_KEY = 'xy';
+    public const MM_TYPE = 'focuspoint_media_detail';
+    public const MED_DEFAULT = 'med_focuspoint';
+    public const META_FIELD_TYPE = 'Focuspoint (AddOn)';
+    public const HTML_PATTERN = '^(100|[1-9]?[0-9])\.[0-9],(100|[1-9]?[0-9])\.[0-9]$';
+    public const PATTERN = '/^(?<x>(100|[1-9]?\d)\.\d),(?<y>(100|[1-9]?\d)\.\d)$/';
+    public const STRING = '%3.1F,%3.1F';
 
     /** @var array<int> */
-    static $mitte = [50,50];
-    
+    public static $mitte = [50, 50];
+
     /** @var array<string> */
-    static $internalEffects = [ 'focuspoint_fit', 'focuspoint_resize' ];
+    public static $internalEffects = ['focuspoint_fit', 'focuspoint_resize'];
 
     /**
      *  Wandelt einen Fokuspunkt-Koordinaten-String in eine numerische Darstellung um.
@@ -43,22 +42,22 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
      *  Ist der Parameter $wh angegeben, werden die Koordinaten in absolute Werte umgerechnet.
      *
      *  @param  string          $xy     Zeichenkette mit dem Koordinaten-Paar ("12.3,34.5")
-     *  @param  array<mixed>    $wh     Array [breite,höhe] mit den Referenzwerten, auf die sich
-     *                                  die Prozentwerte der Koordinaten beziehen.
+     *  @param  array<mixed>    $wh     array [breite,höhe] mit den Referenzwerten, auf die sich
+     *                                  die Prozentwerte der Koordinaten beziehen
      *
      *  @return array<float>|bool       [x,y] als Koordinaten-Array oder false für ungültiger String
      */
-    static public function str2fp( string $xy, array $wh=null )
+    public static function str2fp(string $xy, ?array $wh = null)
     {
-        if( $i = preg_match_all( self::PATTERN, (string)$xy, $tags ) )
-        {
-            $xy = [ min( 100, max( 0, $tags['x'][0] ) ), min( 100, max( 0, $tags['y'][0] ) ) ];
-            if( $wh ) $xy = self::rel2px( $xy, $wh );
+        if ($i = preg_match_all(self::PATTERN, (string) $xy, $tags)) {
+            $xy = [min(100, max(0, $tags['x'][0])), min(100, max(0, $tags['y'][0]))];
+            if ($wh) {
+                $xy = self::rel2px($xy, $wh);
+            }
             return $xy;
         }
         return false;
     }
-
 
     /**
      *  rechnet relative Fokuspunkt-Koordinaten in absolute um.
@@ -68,15 +67,15 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
      *
      *  @return array<integer>            [x,y] als absolute Werte der Fokuspunkt-Koordinate
      */
-    static public function rel2px( array $xy, array $wh )
+    public static function rel2px(array $xy, array $wh)
     {
-        $xy[0] = (int) round( ($wh[0]-1) * $xy[0] / 100 ) ;
-        $xy[1] = (int) round( ($wh[1]-1) * $xy[1] / 100  );
+        $xy[0] = (int) round(($wh[0] - 1) * $xy[0] / 100);
+        $xy[1] = (int) round(($wh[1] - 1) * $xy[1] / 100);
         return $xy;
     }
 
     /**
-     *  Ermittelt den "Default-Fokus"
+     *  Ermittelt den "Default-Fokus".
      *
      *  Basis ist das Feld 'focus' in dem der Defaultwert für den Effekt konfiguriert ist
      *  Sollt das Feld leer sein oder ungültig, wird der angegebene $default herangezogen.
@@ -87,19 +86,20 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
      *
      *  @return array<float>                [x,y] als Koordinaten-Array
      */
-    public function getDefaultFocus( array $default=null, array $wh=null )
+    public function getDefaultFocus(?array $default = null, ?array $wh = null)
     {
-        $xy = self::str2fp( $this->params['focus'] );
-        if( !$xy ) {
-            $xy = $default === null ? self::$mitte : $default;
+        $xy = self::str2fp($this->params['focus']);
+        if (!$xy) {
+            $xy = null === $default ? self::$mitte : $default;
         }
-        if( $wh ) $xy = self::rel2px( $xy, $wh );
+        if ($wh) {
+            $xy = self::rel2px($xy, $wh);
+        }
         return $xy;
     }
 
-
     /**
-     *  Ermittelt das relevante Fokuspunkt-Meta-Feld für den Effekt
+     *  Ermittelt das relevante Fokuspunkt-Meta-Feld für den Effekt.
      *
      *  Das Feld 'meta' des Efektes enthält den Namen des Fokuspunkt-Meta-Feldes.
      *  steht er auf 'defaut', ist kein Meta-Feld ausgewählt.
@@ -108,12 +108,11 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
      */
     public function getMetaField()
     {
-        return str_starts_with($this->params['meta'],'default ') ? '' : $this->params['meta'];
+        return str_starts_with($this->params['meta'], 'default ') ? '' : $this->params['meta'];
     }
 
-
     /**
-     *  Ermittelt die im Effekt anzuwendenden Fokuspunkt-Koordinaten
+     *  Ermittelt die im Effekt anzuwendenden Fokuspunkt-Koordinaten.
      *
      *  Vorgeschaltet ist die Auswertung der URL. Über den REX_API_CALL "focuspoint"
      *  können ebenfalls bearbeitete Bilder erzeugt werden. Die Fokuspunkt-Effekte
@@ -124,30 +123,29 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
      *  @param  focuspoint_media    $media    Media-Objekt oder null
      *  @param  array<mixed>        $default  Default-Koordinaten falls auf anderem Wege keine
      *                                        gültigen Koordinaten ermittelt werden können
-     *  @param  array<mixed>        $wh       Array [breite,höhe] mit den Referenzwerten, auf die
-     *                                        sich die Prozentwerte der Koordinaten beziehen.
+     *  @param  array<mixed>        $wh       array [breite,höhe] mit den Referenzwerten, auf die
+     *                                        sich die Prozentwerte der Koordinaten beziehen
      *
      *  @return array<float>                  [x,y] als Koordinaten-Array
      */
-    function getFocus( $media=null, array $default=null, array $wh=null )
+    public function getFocus($media = null, ?array $default = null, ?array $wh = null)
     {
-        if( $xy = rex_request( self::URL_KEY, 'string', null) )
-        {
-			// nur relevant für temporäre Bilder; funktioniert nicht mit Cache!
-			// hier eingebaut zur Funktionsfähigkeit von focuspoint_api
-			$fp = self::str2fp( $xy );
-			if( !$fp ) {
-				$fp = $media !== null && is_a($media,'focuspoint_media')
-					? $media->getFocus( $xy, $default ) // $xy = Meta-Feld-Name??
-					: $this->getDefaultFocus( $default );
-			}
-		} else {
-			// Standard
-			$fp = $media !== null && is_a($media,'focuspoint_media')
-				? $media->getFocus( $this->getMetaField(), $default )
-				: $this->getDefaultFocus( $default );
-		}
-        return $wh ? self::rel2px( $fp,$wh ) : $fp;
+        if ($xy = rex_request(self::URL_KEY, 'string', null)) {
+            // nur relevant für temporäre Bilder; funktioniert nicht mit Cache!
+            // hier eingebaut zur Funktionsfähigkeit von focuspoint_api
+            $fp = self::str2fp($xy);
+            if (!$fp) {
+                $fp = null !== $media && is_a($media, 'focuspoint_media')
+                    ? $media->getFocus($xy, $default) // $xy = Meta-Feld-Name??
+                    : $this->getDefaultFocus($default);
+            }
+        } else {
+            // Standard
+            $fp = null !== $media && is_a($media, 'focuspoint_media')
+                ? $media->getFocus($this->getMetaField(), $default)
+                : $this->getDefaultFocus($default);
+        }
+        return $wh ? self::rel2px($fp, $wh) : $fp;
 
     }
 
@@ -163,11 +161,13 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
     public function getParams()
     {
 
-        $qry = 'SELECT id,name FROM '.rex::getTable('metainfo_field').' WHERE type_id=(SELECT id FROM '.rex::getTable('metainfo_type').' WHERE label="'.self::META_FIELD_TYPE.'"  LIMIT 1) AND name LIKE "med_%" ORDER BY name ASC';
-        $felder = rex_sql::factory()->getArray( $qry, [], PDO::FETCH_KEY_PAIR );
-        $felder[] = 'default => '.rex_i18n::msg('focuspoint_edit_label_focus');
+        $qry = 'SELECT id,name FROM ' . rex::getTable('metainfo_field') . ' WHERE type_id=(SELECT id FROM ' . rex::getTable('metainfo_type') . ' WHERE label="' . self::META_FIELD_TYPE . '"  LIMIT 1) AND name LIKE "med_%" ORDER BY name ASC';
+        $felder = rex_sql::factory()->getArray($qry, [], PDO::FETCH_KEY_PAIR);
+        $felder[] = 'default => ' . rex_i18n::msg('focuspoint_edit_label_focus');
         $default = current($felder);
-        if( ($k = array_search(self::MED_DEFAULT,$felder)) !== false ) $default = $felder[$k];
+        if (($k = array_search(self::MED_DEFAULT, $felder)) !== false) {
+            $default = $felder[$k];
+        }
         return [
             [
                 'label' => rex_i18n::msg('focuspoint_edit_label_meta'),
@@ -180,11 +180,10 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
                 'label' => rex_i18n::msg('focuspoint_edit_label_focus'),
                 'name' => 'focus',
                 'type' => 'string',
-                'attributes' => [ 'pattern' => self::HTML_PATTERN ],
+                'attributes' => ['pattern' => self::HTML_PATTERN],
                 'notice' => 'x,y: 0.0,0.0 ... 100.0,100.0',
-#                'default' => sprintf( self::STRING, self::$mitte[0], self::$mitte[1]),
+                //                'default' => sprintf( self::STRING, self::$mitte[0], self::$mitte[1]),
             ],
         ];
     }
-
 }

--- a/lib/effect_focuspoint_fit.php
+++ b/lib/effect_focuspoint_fit.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.0.4
+ *  @version     4.1.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -43,190 +43,191 @@
  *  erster Buchstabe ist die Grafik: Quelle (s), Ziel (d), Ausschnitt (c), Fokuspunkt der Quelle (f)
  *  zweiter Buchstabe ist die Verwendung: Offset (x bzw. y), Höhe (h), Breite (w), AspectRatio (r)
  *  Beispiel: $dw, $dh, $dr
- *
  */
 
-
+use FriendsOfREDAXO\focuspoint\focuspoint_media;
 
 class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
 {
-	/** @var array<string> */
-	private $optionsZoom = ['0%','25%', '50%', '75%','100%'];
-	/** @var integer */
+    public const PATTERN = '^([1-9]\d*\s*(px)?|(100|[1-9]?\d)(\.\d)?\s*%|[1-9]\d*\s*fr)$';
+    /** @var array<string> */
+    private $optionsZoom = ['0%', '25%', '50%', '75%', '100%'];
+    /** @var int */
     private $targetByAR;
 
-    const PATTERN = '^([1-9]\d*\s*(px)?|(100|[1-9]?\d)(\.\d)?\s*%|[1-9]\d*\s*fr)$';
-
     /**
-     *  Gibt den Namen des MM-Effektes zurück
+     *  Gibt den Namen des MM-Effektes zurück.
      *
      *  @return     string      Effekt-Name
      */
-	public function getName()
-	{
-		return rex_i18n::msg('focuspoint_effect_fit');
-	}
+    public function getName()
+    {
+        return rex_i18n::msg('focuspoint_effect_fit');
+    }
 
     /**
-     *  Erzeugt den Bildeffekt gemäß der obigen Beschreibung
+     *  Erzeugt den Bildeffekt gemäß der obigen Beschreibung.
      *
      *  @return     void
      */
     public function execute()
     {
-		/*
-			Bilddaten
-		*/
-		$this->media->asImage();
-		$gdimage = $this->media->getImage();
-		$sw = $this->media->getWidth();
-		$sh = $this->media->getHeight();
-		$sr = $sw / $sh;
+        /*
+            Bilddaten
+        */
+        $this->media->asImage();
+        $gdimage = $this->media->getImage();
+        $sw = $this->media->getWidth();
+        $sh = $this->media->getHeight();
+        $sr = $sw / $sh;
 
-		/*
-			Fokuspunkt ermitteln:
-				zuerst den Fallback-Wert bzw. Default-Wert des Effekts
-				dann den FP des Bildes.
-				Umrechnen in absolute Bildkoordinaten (Pixel)
-		*/
-		list( $fx,$fy ) = $this->getFocus( focuspoint_media::get( $this->media->getMediaFilename() ), $this->getDefaultFocus( ), [$sw,$sh] );
+        /*
+            Fokuspunkt ermitteln:
+                zuerst den Fallback-Wert bzw. Default-Wert des Effekts
+                dann den FP des Bildes.
+                Umrechnen in absolute Bildkoordinaten (Pixel)
+        */
+        [$fx, $fy] = $this->getFocus(focuspoint_media::get($this->media->getMediaFilename()), $this->getDefaultFocus(), [$sw, $sh]);
 
-		/*--------------------------
+        /*--------------------------
 
-		Parameter überprüfen und ungültige Werte korrigieren
+        Parameter überprüfen und ungültige Werte korrigieren
 
-			Zielhöhe und/oder Zielbreite müssen angegeben sein. Akzeptiert werden Zahlen und
-			Zahlen mit %, px und fr.
-			Ungültige Werte führen zum Abbruch
-				1111 => Größe in Pixel,
-				1111px => Größe in Pixel
-				11% => % der Originalgröße
-				11fr => "Anteil/fraction" zur Eingabe von Aspect-Ratios des Zielbildes.
-			Ungültige Werte und Wert-Kombinationen führen zum Abbruch
-			Im Fall "fr" müssen beide Werte vom Typ fr sein. 0 oder 2.
-		*/
-			$this->targetByAR = 0;
-			$dw = $this->decodeSize( $this->params['width'],$sw );
-			$dh = $this->decodeSize( $this->params['height'],$sh );
-			if ( empty($dw) && empty($dh) ) return;
-			// Auch wenn rexstan hier meckert, aber es stimmt so: decodeSize incrmentiert targetByAR
-			// @phpstan-ignore-next-line 
-			if ( $this->targetByAR == 1 ) return;
+            Zielhöhe und/oder Zielbreite müssen angegeben sein. Akzeptiert werden Zahlen und
+            Zahlen mit %, px und fr.
+            Ungültige Werte führen zum Abbruch
+                1111 => Größe in Pixel,
+                1111px => Größe in Pixel
+                11% => % der Originalgröße
+                11fr => "Anteil/fraction" zur Eingabe von Aspect-Ratios des Zielbildes.
+            Ungültige Werte und Wert-Kombinationen führen zum Abbruch
+            Im Fall "fr" müssen beide Werte vom Typ fr sein. 0 oder 2.
+        */
+        $this->targetByAR = 0;
+        $dw = $this->decodeSize($this->params['width'], $sw);
+        $dh = $this->decodeSize($this->params['height'], $sh);
+        if (empty($dw) && empty($dh)) {
+            return;
+        }
+        // Auch wenn rexstan hier meckert, aber es stimmt so: decodeSize incrmentiert targetByAR
+        // @phpstan-ignore-next-line
+        if (1 == $this->targetByAR) {
+            return;
+        }
 
-		/*
-			Den Zoom-Faktor auslesen und setzen
-			Entweder soll nur der Auschnitt genommen werden (0%) oder möglichst viel vom
-			Rest (best fit=100%) oder eben eine der Zwischenstufen 25,50 oder 75%.
-			Falls Breite/Höhe als AspectRatio (fr) angegeben wurden: immer 100%
-		*/
-			switch ( $this->params['zoom'] )
-			{
-				case $this->optionsZoom[1]: $zoom = 0.25; break;
-				case $this->optionsZoom[2]: $zoom = 0.5; break;
-				case $this->optionsZoom[3]: $zoom = 0.75; break;
-				case $this->optionsZoom[4]: $zoom = 1; break;
-				default: $zoom = 0;
-			}
+        /*
+            Den Zoom-Faktor auslesen und setzen
+            Entweder soll nur der Auschnitt genommen werden (0%) oder möglichst viel vom
+            Rest (best fit=100%) oder eben eine der Zwischenstufen 25,50 oder 75%.
+            Falls Breite/Höhe als AspectRatio (fr) angegeben wurden: immer 100%
+        */
+        switch ($this->params['zoom']) {
+            case $this->optionsZoom[1]: $zoom = 0.25;
+                break;
+            case $this->optionsZoom[2]: $zoom = 0.5;
+                break;
+            case $this->optionsZoom[3]: $zoom = 0.75;
+                break;
+            case $this->optionsZoom[4]: $zoom = 1;
+                break;
+            default: $zoom = 0;
+        }
 
-		/*--------------------------
-		An die Arbeit ... :
+        /*--------------------------
+        An die Arbeit ... :
 
-			Das Zielformat bestimmen:
+            Das Zielformat bestimmen:
 
-				Breite x Höhe angegeben => wie angegeben nehmen
-				Nur Breite angegeben    => Höhe über den AspectRatio des Originals bestimmen
-				Nur Höhe angegeben      => Breite über den AspectRatio des Originals bestimmen
-		*/
-			$dw = empty( $dw ) ? $dh * $sr : $dw;
-			$dh = empty( $dh ) ? $dw / $sr : $dh;
-			$dr = $dw / $dh;
-			$too_wide = ( $sr >= $dr );
+                Breite x Höhe angegeben => wie angegeben nehmen
+                Nur Breite angegeben    => Höhe über den AspectRatio des Originals bestimmen
+                Nur Höhe angegeben      => Breite über den AspectRatio des Originals bestimmen
+        */
+        $dw = empty($dw) ? $dh * $sr : $dw;
+        $dh = empty($dh) ? $dw / $sr : $dh;
+        $dr = $dw / $dh;
+        $too_wide = ($sr >= $dr);
 
-		/*
-			Im Fall, dass die Bildgröße via AspectRatio angegeben wird, wie z.B. mit Breite 16fr
-			und  Höhe 9fr, was 16:9 entspricht), muss das Zielformat auf die Bildgröße
-			geändert werden. Zoom ist dann irrelevant.
-		*/
-			// Auch wenn rexstan hier meckert, aber es stimmt so: decodeSize incrmentiert targetByAR
-			// @phpstan-ignore-next-line 
-			if ( $this->targetByAR == 2)
-			{
-                                $dw = $too_wide ? floor($sh * $dr) : $sw;
-                                $dh = $too_wide ? $sh : floor($sw / $dr);
-				$zoom = 0;
-			}
-		/*
-			Den Ausschnitt festlegen - Basisgröße
+        /*
+            Im Fall, dass die Bildgröße via AspectRatio angegeben wird, wie z.B. mit Breite 16fr
+            und  Höhe 9fr, was 16:9 entspricht), muss das Zielformat auf die Bildgröße
+            geändert werden. Zoom ist dann irrelevant.
+        */
+        // Auch wenn rexstan hier meckert, aber es stimmt so: decodeSize incrmentiert targetByAR
+        // @phpstan-ignore-next-line
+        if (2 == $this->targetByAR) {
+            $dw = $too_wide ? floor($sh * $dr) : $sw;
+            $dh = $too_wide ? $sh : floor($sw / $dr);
+            $zoom = 0;
+        }
+        /*
+            Den Ausschnitt festlegen - Basisgröße
 
-				Das Zielformat und das Auschnittsformat ist identisch. Aber beide Dimensionen dürfen
-				nicht größer sein als die Bildgröße. Ist eine Dimension zu klein wird das
-				Ausschnittsformat entsprechend reduziert.
-				(anders gesagt: das Bild wird vergrößert)
-		*/
-			$cw = $dw;
-			$ch = $dh;
-			if ( $sw < $cw || $sh < $ch )
-			{
-				$scale = ( $too_wide ? $sh/$dh : $sw/$dw  );
-				$cw = floor( $cw * $scale );
-				$ch = floor( $ch * $scale );
-			}
-		/*
-			Den Ausschnitt festlegen - Zoomen
+                Das Zielformat und das Auschnittsformat ist identisch. Aber beide Dimensionen dürfen
+                nicht größer sein als die Bildgröße. Ist eine Dimension zu klein wird das
+                Ausschnittsformat entsprechend reduziert.
+                (anders gesagt: das Bild wird vergrößert)
+        */
+        $cw = $dw;
+        $ch = $dh;
+        if ($sw < $cw || $sh < $ch) {
+            $scale = ($too_wide ? $sh / $dh : $sw / $dw);
+            $cw = floor($cw * $scale);
+            $ch = floor($ch * $scale);
+        }
+        /*
+            Den Ausschnitt festlegen - Zoomen
 
-				Grade wenn große Bilder auf einen kleinen Ausschnitt treffen, wäre ein Zoom
-				sinnvoll. Der Zoom-Faktor sagt, wieviel % vom Abstand zwischen Originalbild und
-				Ausschnitt mit hineingenooen werden sollen. Faktisch wird der Ausschnitt um einen
-				entsprechenden Faktor vergrößert.
-		*/
-			if ( $zoom )
-			{
-				$faktor = $too_wide ? (($sh-$ch) * $zoom + $ch) / $ch : (($sw-$cw) * $zoom + $cw) / $cw;
-				$cw = floor( $cw * $faktor );
-				$ch = floor( $ch * $faktor );
-			}
-		/*
-			Den Bildauschnitt positionieren:
+                Grade wenn große Bilder auf einen kleinen Ausschnitt treffen, wäre ein Zoom
+                sinnvoll. Der Zoom-Faktor sagt, wieviel % vom Abstand zwischen Originalbild und
+                Ausschnitt mit hineingenooen werden sollen. Faktisch wird der Ausschnitt um einen
+                entsprechenden Faktor vergrößert.
+        */
+        if ($zoom) {
+            $faktor = $too_wide ? (($sh - $ch) * $zoom + $ch) / $ch : (($sw - $cw) * $zoom + $cw) / $cw;
+            $cw = floor($cw * $faktor);
+            $ch = floor($ch * $faktor);
+        }
+        /*
+            Den Bildauschnitt positionieren:
 
-				Der Bildausschnitt wird so gelegt, dass der Fokuspunkt in der Mitte liegt.
-				Falls dann der Ausschnitt irgendwo über die Ränder ragt, wird er in das Bild
-				zurückgeschoben. Der Fokuspunkt ist dann natürlich nicht mehr in der Mitte.
-				Das Ergebnis ist die Offset-Position des Auschnitts im Originalbild.
-		*/
-			$cx = $fx - floor( $cw/2 );
-			$cy = $fy - floor( $ch/2 );
-			$cx = min( $sw-$cw, max( 0,$cx ) );
-			$cy = min( $sh-$ch, max( 0,$cy ) );
+                Der Bildausschnitt wird so gelegt, dass der Fokuspunkt in der Mitte liegt.
+                Falls dann der Ausschnitt irgendwo über die Ränder ragt, wird er in das Bild
+                zurückgeschoben. Der Fokuspunkt ist dann natürlich nicht mehr in der Mitte.
+                Das Ergebnis ist die Offset-Position des Auschnitts im Originalbild.
+        */
+        $cx = $fx - floor($cw / 2);
+        $cy = $fy - floor($ch / 2);
+        $cx = min($sw - $cw, max(0, $cx));
+        $cy = min($sh - $ch, max(0, $cy));
 
-		/*--------------------------
+        /*--------------------------
 
-			Ausgabe der Grafik
-		*/
-		if (function_exists('ImageCreateTrueColor')) {
-			$des = @imagecreatetruecolor($dw, $dh);
-		} else {
-			$des = @imagecreate($dw, $dh);
-		}
+            Ausgabe der Grafik
+        */
+        if (function_exists('ImageCreateTrueColor')) {
+            $des = @imagecreatetruecolor($dw, $dh);
+        } else {
+            $des = @imagecreate($dw, $dh);
+        }
 
-		if (!$des) {
-			return;
-		}
+        if (!$des) {
+            return;
+        }
 
-		// Die Fehlermeldung von rexstan beruht auf der Prüfung gegen PHP8. Dort sind GD-Objekte vom Typ "GdImage" und nicht "resoource"
-		// Daher werden nachfolgend drei Zeilen ignoriert.
-		// @phpstan-ignore-next-line
-		$this->keepTransparent($des);
-		// @phpstan-ignore-next-line
-		imagecopyresampled($des, $gdimage,
-		    0, 0, (int)$cx, (int)$cy,
-		    (int)$dw, (int)$dh, (int)$cw, (int)$ch);
+        // Die Fehlermeldung von rexstan beruht auf der Prüfung gegen PHP8. Dort sind GD-Objekte vom Typ "GdImage" und nicht "resoource"
+        // Daher werden nachfolgend drei Zeilen ignoriert.
+        // @phpstan-ignore-next-line
+        $this->keepTransparent($des);
+        // @phpstan-ignore-next-line
+        imagecopyresampled($des, $gdimage,
+            0, 0, (int) $cx, (int) $cy,
+            (int) $dw, (int) $dh, (int) $cw, (int) $ch);
 
-		// @phpstan-ignore-next-line
-		$this->media->setImage($des);
-		$this->media->refreshImageDimensions();
+        // @phpstan-ignore-next-line
+        $this->media->setImage($des);
+        $this->media->refreshImageDimensions();
 
-	}
-
+    }
 
     /**
      *  Stellt die Felder für die Effekt-Konfiguration als Array bereit.
@@ -241,26 +242,26 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
         $felder = parent::getParams();
         $info = rex_i18n::msg('focuspoint_edit_notice_widthheigth_fit');
         $felder[] = [
-                        'label' => rex_i18n::msg('focuspoint_edit_label_width'),
-                        'name' => 'width',
-                        'type' => 'int',
-                        'notice' => $info,
-                        'attributes' => [ 'pattern' => self::PATTERN ],
-                    ];
+            'label' => rex_i18n::msg('focuspoint_edit_label_width'),
+            'name' => 'width',
+            'type' => 'int',
+            'notice' => $info,
+            'attributes' => ['pattern' => self::PATTERN],
+        ];
         $felder[] = [
-                        'label' => rex_i18n::msg('focuspoint_edit_label_heigth'),
-                        'name' => 'height',
-                        'type' => 'int',
-                        'notice' => $info,
-                        'attributes' => [ 'pattern' => self::PATTERN ],
-                    ];
+            'label' => rex_i18n::msg('focuspoint_edit_label_heigth'),
+            'name' => 'height',
+            'type' => 'int',
+            'notice' => $info,
+            'attributes' => ['pattern' => self::PATTERN],
+        ];
         $felder[] = [
-                        'label' => rex_i18n::msg('focuspoint_edit_label_zoom'),
-                        'name' => 'zoom',
-                        'type' => 'select',
-                        'options' => $this->optionsZoom,
-                        'notice' => rex_i18n::msg('focuspoint_edit_notice_zoom'),
-                    ];
+            'label' => rex_i18n::msg('focuspoint_edit_label_zoom'),
+            'name' => 'zoom',
+            'type' => 'select',
+            'options' => $this->optionsZoom,
+            'notice' => rex_i18n::msg('focuspoint_edit_notice_zoom'),
+        ];
 
         return $felder;
     }
@@ -277,24 +278,25 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
      *
      *  @return   float|null    umgerechneter Wert oder null für ungültiges Format
      */
-    function decodeSize( $value, $ref=0 )
+    public function decodeSize($value, $ref = 0)
     {
-        $value = trim( (string)$value );
-        if ( !preg_match( '/'.self::PATTERN.'/', $value ) ) return null;
-        if ( strpos( $value,'%' ) )
-        {
-            $value = trim(str_replace( '%','',$value));
-            $value = max( 0, min( 100, $value ) );
-            if( $ref ) $value = $ref * $value / 100;
-            return (float)$value;
+        $value = trim((string) $value);
+        if (!preg_match('/' . self::PATTERN . '/', $value)) {
+            return null;
         }
-        if ( strpos( $value,'fr' ) )
-        {
-            $value = trim(str_replace( 'fr','',$value));
-            $this->targetByAR++;
-            return (int)$value;
+        if (strpos($value, '%')) {
+            $value = trim(str_replace('%', '', $value));
+            $value = max(0, min(100, $value));
+            if ($ref) {
+                $value = $ref * $value / 100;
+            }
+            return (float) $value;
         }
-        return (int)trim(str_replace( 'px','',$value));
+        if (strpos($value, 'fr')) {
+            $value = trim(str_replace('fr', '', $value));
+            ++$this->targetByAR;
+            return (int) $value;
+        }
+        return (int) trim(str_replace('px', '', $value));
     }
-
 }

--- a/lib/effect_focuspoint_fit.php
+++ b/lib/effect_focuspoint_fit.php
@@ -45,7 +45,7 @@
  *  Beispiel: $dw, $dh, $dr
  */
 
-use FriendsOfREDAXO\focuspoint\focuspoint_media;
+use FriendsOfRedaxo\focuspoint\focuspoint_media;
 
 class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
 {

--- a/lib/focuspoint.php
+++ b/lib/focuspoint.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.0.2
+ *  @version     4.1.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -16,9 +16,24 @@
  *  aufgerufen werden
  */
 
+namespace FriendsOfREDAXO\focuspoint;
+
+use PDO;
+use rex;
+use rex_effect_abstract_focuspoint;
+use rex_extension;
+use rex_extension_point;
+use rex_fragment;
+use rex_i18n;
+use rex_media_manager;
+use rex_sql;
+use rex_url;
+
+use function count;
+use function strlen;
+
 class focuspoint
 {
-
     /**
      *  Erzeugt den HTML-Code, der in der Sidebar des Media-Detailformulars zur interaktiven
      *  Auswahl des Fokuspunktes eingebaut wird.
@@ -35,22 +50,19 @@ class focuspoint
      *
      *  Das HTML wird vom Fragment "fp_panel.php" erzeugt.
      *
-     *  @param  rex_extension_point $ep
-     *
      *  @return string|void   modifiziertes Sidebar-Html | keine Änderung
      */
 
     // rexstan meldet: "Method focuspoint::show_sidebar() has parameter $ep with generic class rex_extension_point but does not specify its types: T"
     // Warum?? Einfach ignorieren
-    public static function show_sidebar( rex_extension_point $ep )
+    public static function show_sidebar(rex_extension_point $ep)
     {
         $params = $ep->getParams();
 
         // Abbruch wenn kein Bild; Metafelder ausblenden
         // der Flag focuspoint_no_image wird in customfield ausgewertet, da dort keine passenden Informationen verfügbar sind.
-        if( !$params['is_image'] )
-        {
-            rex::setProperty('focuspoint_no_image',true);
+        if (!$params['is_image']) {
+            rex::setProperty('focuspoint_no_image', true);
             return;
         }
 
@@ -66,51 +78,57 @@ class focuspoint
         $text = $ep->getSubject();
         $mediafile = $params['filename'];
 
-        $referenz = '<a href="'.rex_media_manager::getUrl('rex_media_large', urlencode($mediafile) );
-        $p1 = stripos( $text, $referenz );
+        $referenz = '<a href="' . rex_media_manager::getUrl('rex_media_large', urlencode($mediafile));
+        $p1 = stripos($text, $referenz);
 
-        if( $p1 === false ) return;
+        if (false === $p1) {
+            return;
+        }
 
-        $p2 = stripos( $text, '</a>', $p1 + strlen($referenz) );
-        if( $p2 === false ) return;
+        $p2 = stripos($text, '</a>', $p1 + strlen($referenz));
+        if (false === $p2) {
+            return;
+        }
         $p2 = $p2 + 4;
 
-
         $fragment = new rex_fragment();
-        $fragment->setVar ('mediafile', $mediafile );
+        $fragment->setVar('mediafile', $mediafile);
 
         // relevante Media-Typen abrufen (nur Mediatypes, die Fokuspoint-Effekte beinhalten)
         // benutze Felder zuordnen
         // array[typ] = [ feld1, feld2, ...]
-        $typen = array_unique( array_column( $params['effectsInUse']=self::getFocuspointEffectsInUse(), 'name' ) );
-        asort( $typen );
-        $typen = array_combine($typen,array_fill(0,count($typen),[]));
-        foreach( self::getMetafieldList( ) as $f ) {
-            foreach( self::getFocuspointMetafieldInUse( $f ) as $e ) $typen[$e['name']][] = $f;
+        $typen = array_unique(array_column($params['effectsInUse'] = self::getFocuspointEffectsInUse(), 'name'));
+        asort($typen);
+        $typen = array_combine($typen, array_fill(0, count($typen), []));
+        foreach (self::getMetafieldList() as $f) {
+            foreach (self::getFocuspointMetafieldInUse($f) as $e) {
+                $typen[$e['name']][] = $f;
+            }
         }
-        array_walk( $typen, function(&$t, $k) { $t = ['label'=>$k,'meta'=>$t]; });
+        array_walk($typen, static function (&$t, $k) {
+            $t = ['label' => $k, 'meta' => $t];
+        });
 
         $typen = rex_extension::registerPoint(new rex_extension_point('FOCUSPOINT_PREVIEW_SELECT', $typen, $params));
-        $fragment->setVar( 'mediatypes', $typen );
+        $fragment->setVar('mediatypes', $typen);
 
         // Option-Liste der Felder aufbauen - falls es mindestens zwei Felder und davon mindestens ein hidden-Feld gibt.
-        $qry = 'SELECT name,title,params FROM '.rex::getTable('metainfo_field').' WHERE name LIKE "med_%" AND type_id = (SELECT id FROM '.rex::getTable('metainfo_type').' WHERE label="'.rex_effect_abstract_focuspoint::META_FIELD_TYPE.'") ORDER BY priority ASC';
-        $felder = rex_sql::factory()->getArray( $qry );
-        if( count($felder) > 1 )
-        {
+        $qry = 'SELECT name,title,params FROM ' . rex::getTable('metainfo_field') . ' WHERE name LIKE "med_%" AND type_id = (SELECT id FROM ' . rex::getTable('metainfo_type') . ' WHERE label="' . rex_effect_abstract_focuspoint::META_FIELD_TYPE . '") ORDER BY priority ASC';
+        $felder = rex_sql::factory()->getArray($qry);
+        if (count($felder) > 1) {
             $feldauswahl = [];
             $hidden = false;
-            foreach( $felder as $feld )
-            {
-                $feldauswahl[ $feld['name'] ] = $feld['title'] ? rex_i18n::translate($feld['title']) : htmlspecialchars($feld['name']);
-                $hidden = $hidden || strtolower($feld['params']) == 'hidden';
+            foreach ($felder as $feld) {
+                $feldauswahl[$feld['name']] = $feld['title'] ? rex_i18n::translate($feld['title']) : htmlspecialchars($feld['name']);
+                $hidden = $hidden || 'hidden' == strtolower($feld['params']);
             }
-            if( $hidden ) $fragment->setVar( 'fieldselect', $feldauswahl );
+            if ($hidden) {
+                $fragment->setVar('fieldselect', $feldauswahl);
+            }
         }
 
-        return substr_replace( $text, $fragment->parse('fp_panel.php'), $p1, $p2 - $p1 );
+        return substr_replace($text, $fragment->parse('fp_panel.php'), $p1, $p2 - $p1);
     }
-
 
     /**
      *  Die Funktion liefert das Feld-HTML für Fokuspunkt-Felder (Meta-Typ "Focuspoint (AddOn)").
@@ -122,19 +140,19 @@ class focuspoint
      *
      *  Das HTML wird vom Fragment "fp_metafield.php" erzeugt.
      *
-     *  @param  rex_extension_point $ep
-     *
      *  @return array<mixed>|void   Metafield-Html, ....
      */
 
     // rexstan meldet: "Method focuspoint::customfield() has parameter $ep with generic class rex_extension_point but does not specify its types: T"
     // Warum?? Einfach ignorieren
-    public static function customfield( rex_extension_point $ep )
+    public static function customfield(rex_extension_point $ep)
     {
         $subject = $ep->getSubject();
-        if( $subject['type'] != rex_effect_abstract_focuspoint::META_FIELD_TYPE ) return;
+        if (rex_effect_abstract_focuspoint::META_FIELD_TYPE != $subject['type']) {
+            return;
+        }
         $default = $subject['sql']->getValue('default');
-        if( !rex_effect_abstract_focuspoint::str2fp($subject['sql']->getValue('default') ) ) {
+        if (!rex_effect_abstract_focuspoint::str2fp($subject['sql']->getValue('default'))) {
             $default = '';
         }
 
@@ -142,15 +160,15 @@ class focuspoint
         // image, the fopuspoint-meta-fields don´t make any sense and will be flagged as hidden.
         // as of V2.2 the fields are still available just for not cousing a BC.
         // A future V3.0 will instead stop generating the HTML.
-        $hidden = rex::getProperty('focuspoint_no_image',false) === true;
-    
+        $hidden = true === rex::getProperty('focuspoint_no_image', false);
+
         $feld = new rex_fragment();
-        $feld->setVar( 'label', $subject[4], false );
-        $feld->setVar( 'id', $subject[3] );
-        $feld->setVar( 'name', str_replace('rex-metainfo-','',$subject[3]) );
-        $feld->setVar( 'value', $subject['values'][0] );
-        $feld->setVar( 'default', $default );
-        $feld->setVar( 'hidden', $hidden || strtolower(trim($subject['sql']->getValue('params'))) == 'hidden' );
+        $feld->setVar('label', $subject[4], false);
+        $feld->setVar('id', $subject[3]);
+        $feld->setVar('name', str_replace('rex-metainfo-', '', $subject[3]));
+        $feld->setVar('value', $subject['values'][0]);
+        $feld->setVar('default', $default);
+        $feld->setVar('hidden', $hidden || 'hidden' == strtolower(trim($subject['sql']->getValue('params'))));
 
         $subject[0] = $feld->parse('fp_metafield.php');
         return $subject;
@@ -168,29 +186,25 @@ class focuspoint
      *
      *  @return string
      */
-
     public static function checkUninstallDependencies()
     {
         $message = '';
 
         // ermittle die Meta-Felder vom Typ 'Focuspoint (AddOn)', die nicht 'med_focuspoint' sind.
-        if( $felder = self::getMetafieldList( true ) )
-        {
-            $message .= '<li>' . rex_i18n::msg('focuspoint_uninstall_metafields', rex_effect_abstract_focuspoint::META_FIELD_TYPE ) .
-                        '<ul><li>' . implode('</li><li>',$felder) .
+        if ($felder = self::getMetafieldList(true)) {
+            $message .= '<li>' . rex_i18n::msg('focuspoint_uninstall_metafields', rex_effect_abstract_focuspoint::META_FIELD_TYPE) .
+                        '<ul><li>' . implode('</li><li>', $felder) .
                         '</li></ul></li>';
         }
 
         // ermittle alle Effekte der Liste, die im Media-Manager genutzt werden
-        if( $mmEffekteMsg = self::getFocuspointEffectsInUse() )
-        {
-            $mmEffekteMsg = self::getFocuspointEffectsInUseMessage( $mmEffekteMsg );
+        if ($mmEffekteMsg = self::getFocuspointEffectsInUse()) {
+            $mmEffekteMsg = self::getFocuspointEffectsInUseMessage($mmEffekteMsg);
             $message .= "<li>$mmEffekteMsg</li>";
         }
 
-        if( $message )
-        {
-            $message = '<strong>' . rex_i18n::msg( 'focuspoint_uninstall_dependencies' ) . "</strong><ul>$message</ul>";
+        if ($message) {
+            $message = '<strong>' . rex_i18n::msg('focuspoint_uninstall_dependencies') . "</strong><ul>$message</ul>";
         }
         return $message;
     }
@@ -207,33 +221,30 @@ class focuspoint
      *
      *  @return string
      */
-
     public static function checkActivateDependencies()
     {
         $message = '';
         $sql = rex_sql::factory();
         $qry = 'SELECT id FROM ' . rex::getTable('metainfo_type') . ' WHERE label=:label LIMIT 1';
         $sql->setQuery($qry, [':label' => rex_effect_abstract_focuspoint::META_FIELD_TYPE]);
-        if( $sql->getRows() == 0 ) {
-            $message .= '<li>'.rex_i18n::msg( 'focuspoint_activate_missing_metainfotype' ).'</li>';
+        if (0 == $sql->getRows()) {
+            $message .= '<li>' . rex_i18n::msg('focuspoint_activate_missing_metainfotype') . '</li>';
         }
         $qry = 'SELECT type_id FROM ' . rex::getTable('metainfo_field') . ' WHERE name=:name LIMIT 1';
         $sql->setQuery($qry, [':name' => rex_effect_abstract_focuspoint::MED_DEFAULT]);
-        if( $sql->getRows() == 0 ) {
-            $message .= '<li>'.rex_i18n::msg( 'focuspoint_activate_missing_metainfofield' ).'</li>';
+        if (0 == $sql->getRows()) {
+            $message .= '<li>' . rex_i18n::msg('focuspoint_activate_missing_metainfofield') . '</li>';
         }
         $qry = 'SELECT id FROM ' . rex::getTable('media_manager_type') . ' WHERE name=:name LIMIT 1';
         $sql->setQuery($qry, [':name' => rex_effect_abstract_focuspoint::MM_TYPE]);
-        if( $sql->getRows() == 0 ) {
-            $message .= '<li>'.rex_i18n::msg( 'focuspoint_activate_missing_mediamanagertype' ).'</li>';
+        if (0 == $sql->getRows()) {
+            $message .= '<li>' . rex_i18n::msg('focuspoint_activate_missing_mediamanagertype') . '</li>';
         }
-        if( $message )
-        {
-            $message = '<strong>' . rex_i18n::msg( 'focuspoint_activate_dependencies' ) . "</strong><ul>$message</ul>";
+        if ($message) {
+            $message = '<strong>' . rex_i18n::msg('focuspoint_activate_dependencies') . "</strong><ul>$message</ul>";
         }
         return $message;
     }
-
 
     /**
      *  Die Funktion überprüft Abhängigkeiten und bereitet die Ergebnisse als HTML-Liste auf.
@@ -245,17 +256,14 @@ class focuspoint
      *
      *  @return string
      */
-
     public static function checkDeactivateDependencies()
     {
-        if( $message = self::getFocuspointEffectsInUse() )
-        {
-            $message = self::getFocuspointEffectsInUseMessage( $message );
-            $message = '<strong>' . rex_i18n::msg( 'focuspoint_deactivate_dependencies' ) . "</strong><br>$message";
+        if ($message = self::getFocuspointEffectsInUse()) {
+            $message = self::getFocuspointEffectsInUseMessage($message);
+            $message = '<strong>' . rex_i18n::msg('focuspoint_deactivate_dependencies') . "</strong><br>$message";
         }
         return $message;
     }
-
 
     /**
      *  Die Funktion ermittelt, ob Fokuspunkt-Meta-Felder in Effekten des Media-Managers benutzt
@@ -269,35 +277,33 @@ class focuspoint
      *  @param  int          $id Nummer des Feldes (Datensatz-Id in rex_metainfo_field)
      *  @return string       leerer String oder Rückmeldung der gefundenen Einträge
      */
-
-    public static function metafield_is_in_use( $id )
+    public static function metafield_is_in_use($id)
     {
         // Name des zu löschenden Metafeldes
-        $feld = self::getMetafieldList( );
-        if( !isset( $feld[$id] ) ) return '';
+        $feld = self::getMetafieldList();
+        if (!isset($feld[$id])) {
+            return '';
+        }
         $feld = $feld[$id];
 
         // Das Default-Feld "med_focuspoint" darf so oder so nie gelöcht werden.
-        if( $feld == rex_effect_abstract_focuspoint::MED_DEFAULT )
-        {
+        if (rex_effect_abstract_focuspoint::MED_DEFAULT == $feld) {
             $result = rex_i18n::msg('focuspoint_isinuse_dontdeletedefault', $feld);
         }
 
         // Andere Felder gezielt überprüfen
-        elseif( $result = self::getFocuspointMetafieldInUse( $feld )  )
-        {
-            $result = '<strong>' .rex_i18n::rawMsg(
-                    'focuspoint_isinuse_message',
-                    $feld,
-                    rex_url::backendController(['page' => 'media_manager/types'])
-                    ) . '</strong><br>' . self::getFocuspointEffectsInUseMessage( $result );
+        elseif ($result = self::getFocuspointMetafieldInUse($feld)) {
+            $result = '<strong>' . rex_i18n::rawMsg(
+                'focuspoint_isinuse_message',
+                $feld,
+                rex_url::backendController(['page' => 'media_manager/types']),
+            ) . '</strong><br>' . self::getFocuspointEffectsInUseMessage($result);
         }
         return $result;
     }
 
-
     /**
-     *  Die Funktion ermittelt die Liste aller Fokuspunkt-Metafelder
+     *  Die Funktion ermittelt die Liste aller Fokuspunkt-Metafelder.
      *
      *  Die Felder werden über den Typ "Focuspoint (AddOn)" identifiziert.
      *
@@ -306,16 +312,16 @@ class focuspoint
      *
      *  @return array<mixed>   Key/Value-Array mit id=>name
      */
-
-    public static function getMetafieldList( $extern=false )
+    public static function getMetafieldList($extern = false)
     {
-        $qry = 'SELECT f.id,name FROM '.
-                rex::getTable('metainfo_field').' f LEFT JOIN '.rex::getTable('metainfo_type').
-                ' t ON f.type_id = t.id WHERE label LIKE "'.rex_effect_abstract_focuspoint::META_FIELD_TYPE.'"';
-        if( $extern ) $qry .= ' AND name NOT LIKE "'.rex_effect_abstract_focuspoint::MED_DEFAULT.'"';
-        return rex_sql::factory()->getArray( $qry, [], PDO::FETCH_KEY_PAIR );
+        $qry = 'SELECT f.id,name FROM ' .
+                rex::getTable('metainfo_field') . ' f LEFT JOIN ' . rex::getTable('metainfo_type') .
+                ' t ON f.type_id = t.id WHERE label LIKE "' . rex_effect_abstract_focuspoint::META_FIELD_TYPE . '"';
+        if ($extern) {
+            $qry .= ' AND name NOT LIKE "' . rex_effect_abstract_focuspoint::MED_DEFAULT . '"';
+        }
+        return rex_sql::factory()->getArray($qry, [], PDO::FETCH_KEY_PAIR);
     }
-
 
     /**
      *  Die Funktion ermittelt die Liste aller Media-Manager-Typen/Effekte, in denen ein gegebenes
@@ -334,47 +340,46 @@ class focuspoint
      *                          id          => id des effektes (rex_media_manager_type_effect)
      *                          parameters  => Parameter des Effektes
      */
-
-    public static function getFocuspointMetafieldInUse( $feld )
+    public static function getFocuspointMetafieldInUse($feld)
     {
-        $effects = self::getFocuspointEffectsInUse( );
-        foreach( $effects as $k=>$v )
-        {
-            $params = json_decode( $v['parameters'], true );
+        $effects = self::getFocuspointEffectsInUse();
+        foreach ($effects as $k => $v) {
+            $params = json_decode($v['parameters'], true);
             $effekt = "rex_effect_{$v['effect']}";
             $meta = "{$effekt}_meta";
-            if( isset($params[$effekt][$meta]) && $params[$effekt][$meta] == $feld ) continue;
-            unset( $effects[$k] );
+            if (isset($params[$effekt][$meta]) && $params[$effekt][$meta] == $feld) {
+                continue;
+            }
+            unset($effects[$k]);
         }
         return $effects;
     }
 
-
     /**
-     *  Die Funktion ermittelt die Liste aller Fokuspunkt-Effekte
+     *  Die Funktion ermittelt die Liste aller Fokuspunkt-Effekte.
      *
      *  Die Effekte werden über die Klasse "rex_effect_abstract_focuspoint" identifiziert, von der
      *  alle, auch externe (nicht mitgelieferte) Effekte abgeleitet sein sollten.
      *
      *  @param  bool $extern    wenn true werden nur Effekte ermittelt, die zusätzlich zu den
-     *                          AddOn-eigenen Effekten beim Media-Manager registriert wurden.
+     *                          AddOn-eigenen Effekten beim Media-Manager registriert wurden
      *
      *  @return array<string>   Key/Value-Array mit rex_effect_«name»=>«name»
      */
-
-    public static function getFocuspointEffects( $extern=false )
+    public static function getFocuspointEffects($extern = false)
     {
         $effects = array_filter(
-                rex_media_manager::getSupportedEffects(),
-                function ($class){ return is_subclass_of( $class, 'rex_effect_abstract_focuspoint');},
-                ARRAY_FILTER_USE_KEY
-            );
-        if( $extern ) {
-            $effects = array_diff( $effects, rex_effect_abstract_focuspoint::$internalEffects );
+            rex_media_manager::getSupportedEffects(),
+            static function ($class) {
+                return is_subclass_of($class, 'rex_effect_abstract_focuspoint');
+            },
+            ARRAY_FILTER_USE_KEY,
+        );
+        if ($extern) {
+            $effects = array_diff($effects, rex_effect_abstract_focuspoint::$internalEffects);
         }
         return $effects;
     }
-
 
     /**
      *  Die Funktion ermittelt die Liste aller Fokuspunkt-Effekte, die in einem Media-Manager-Typ
@@ -387,19 +392,16 @@ class focuspoint
      *                          id          => id des effektes (rex_media_manager_type_effect)
      *                          parameters  => Parameter des Effektes
      */
-
-    public static function getFocuspointEffectsInUse( )
+    public static function getFocuspointEffectsInUse()
     {
-        if( $effects = self::getFocuspointEffects() )
-        {
-            $qry = 'SELECT name, effect, parameters, type_id, a.id as id, description FROM '.
-                    rex::getTable('media_manager_type_effect').' as a, '.rex::getTable('media_manager_type').
-                    ' as b WHERE effect IN ("'.implode( '","',$effects ).'") AND b.id = a.type_id';
-            return rex_sql::factory()->getArray( $qry );
+        if ($effects = self::getFocuspointEffects()) {
+            $qry = 'SELECT name, effect, parameters, type_id, a.id as id, description FROM ' .
+                    rex::getTable('media_manager_type_effect') . ' as a, ' . rex::getTable('media_manager_type') .
+                    ' as b WHERE effect IN ("' . implode('","', $effects) . '") AND b.id = a.type_id';
+            return rex_sql::factory()->getArray($qry);
         }
         return [];
     }
-
 
     /**
      *  Die Funktion bereitet die angegebenen Effekte zu einer UL/LI-Meldung auf.
@@ -407,39 +409,34 @@ class focuspoint
      *  @param  array<mixed> $effekte
      *  @return string
      */
-
-    public static function getFocuspointEffectsInUseMessage( array $effekte )
+    public static function getFocuspointEffectsInUseMessage(array $effekte)
     {
         $message = '';
-        foreach( $effekte as $effect )
-        {
+        foreach ($effekte as $effect) {
             $target = "rex_effect_{$effect['effect']}";
             $name = new $target();
             $message .= '<li>' . rex_i18n::rawMsg(
                 'focuspoint_isinuse_entry',
                 $effect['name'],
                 rex_url::backendController([
-                        'page' => 'media_manager/types',
-                        'type_id' => $effect['type_id'],
-                        'effects' => 1,
-                    ]),
+                    'page' => 'media_manager/types',
+                    'type_id' => $effect['type_id'],
+                    'effects' => 1,
+                ]),
                 $name->getName(),
                 rex_url::backendController([
-                        'page' => 'media_manager/types',
-                        'effects' => 1,
-                        'func' => 'edit',
-                        'type_id' => $effect['type_id'],
-                        'effect_id' => $effect['id'],
-                    ])
-                ) .' / '.$effect['effect'] . '</li>';
+                    'page' => 'media_manager/types',
+                    'effects' => 1,
+                    'func' => 'edit',
+                    'type_id' => $effect['type_id'],
+                    'effect_id' => $effect['id'],
+                ]),
+            ) . ' / ' . $effect['effect'] . '</li>';
 
         }
-        if( $message )
-        {
+        if ($message) {
             $message = "<ul>$message</ul>";
         }
         return $message;
     }
-
-
 }

--- a/lib/focuspoint.php
+++ b/lib/focuspoint.php
@@ -16,7 +16,7 @@
  *  aufgerufen werden
  */
 
-namespace FriendsOfREDAXO\focuspoint;
+namespace FriendsOfRedaxo\focuspoint;
 
 use PDO;
 use rex;

--- a/lib/focuspoint_api.php
+++ b/lib/focuspoint_api.php
@@ -31,49 +31,46 @@
  *               &file=      Name der Mediendatei
  *               &type=      Name des MM-Effektes
  *               &xy=        Fokuspunkt numerisch (0.0,0.0 bis 100.1,100.0)
- *
  */
 
- class rex_api_focuspoint extends rex_api_function {
-
+class rex_api_focuspoint extends rex_api_function
+{
     //	protected $published = true;
 
     /**
-     *  Ausführende Funktion des rex_api_call "focuspoint"
+     *  Ausführende Funktion des rex_api_call "focuspoint".
      *
      *  prüft die Request-Parameter, initiiert die Bilderstellung und sendet das Bild an die Browser
      */
-    public function execute() {
+    public function execute()
+    {
 
-        $mediafile = rex_request( 'file', 'string', '' );
-        $mediatype = rex_request( 'type', 'string', '' );
+        $mediafile = rex_request('file', 'string', '');
+        $mediatype = rex_request('type', 'string', '');
 
-        if( $mediafile && $mediatype )
-        {
-            $bild = focuspoint_media_manager::createMedia( $mediatype, $mediafile );
-            $bild->sendMedia( '', '' );
+        if ($mediafile && $mediatype) {
+            $bild = focuspoint_media_manager::createMedia($mediatype, $mediafile);
+            $bild->sendMedia('', '');
         }
         exit;
     }
-
 }
 
 /**
-*  Da die wichtige Funktion rex_media_manager->applyEffects 'protected' ist, muss eine abgeleitete
-*  Klasse "focuspoint_media_manager" zwischengeschaltet werden, um das neue Bild zu generieren.
-*
-*/
+ *  Da die wichtige Funktion rex_media_manager->applyEffects 'protected' ist, muss eine abgeleitete
+ *  Klasse "focuspoint_media_manager" zwischengeschaltet werden, um das neue Bild zu generieren.
+ */
 class focuspoint_media_manager extends rex_media_manager
 {
     /**
-     *  Erzeugt das Bild des media-Effektes
+     *  Erzeugt das Bild des media-Effektes.
      *
      *  @param  string $type        Medientyp
      *  @param  string $file        Name der Bilddatei im Medienpool
      *
      *  @return rex_managed_media   Ergebnisbild
      */
-    public static function createMedia( $type=null, $file=null )
+    public static function createMedia($type = null, $file = null)
     {
         $mediaPath = rex_path::media($file);
         $media = new rex_managed_media($mediaPath);

--- a/lib/focuspoint_boot.php
+++ b/lib/focuspoint_boot.php
@@ -17,7 +17,7 @@
  *  REDAXO-Instanz eine schlanke boot.php mit geringem Kompilieraufwand zu haben.
  */
 
-namespace FriendsOfREDAXO\focuspoint;
+namespace FriendsOfRedaxo\focuspoint;
 
 use ReflectionException;
 use rex;

--- a/lib/focuspoint_boot.php
+++ b/lib/focuspoint_boot.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.0.2
+ *  @version     4.1.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -15,59 +15,72 @@
  *  besondere Einstellungen z.B. mittels Extension-Points vorzunehmen sind.
  *  Die Aktivitäten wurden in eine separate Datei ausgelagert, um für den Normalbetrieb der
  *  REDAXO-Instanz eine schlanke boot.php mit geringem Kompilieraufwand zu haben.
- *
  */
 
-class focuspoint_boot {
+namespace FriendsOfREDAXO\focuspoint;
 
+use ReflectionException;
+use rex;
+use rex_effect_abstract_focuspoint;
+use rex_extension;
+use rex_extension_point;
+use rex_i18n;
+use rex_sql;
+use rex_view;
+
+use function array_key_exists;
+
+class focuspoint_boot
+{
     /**
-     *  page=mediapool/media
+     *  page=mediapool/media.
      *
      *  Ressourcen für die Fokuspunkt-Erfassung im Mediapool einbinden
-     * 
+     *
      *  @param rex_addon $fpAddon
      *  @return void
      */
-    static public function mediaDetailPage( $fpAddon )
+    public static function mediaDetailPage($fpAddon)
     {
         rex_view::addCssFile($fpAddon->getAssetsUrl('focuspoint.min.css'));
         rex_view::addJsFile($fpAddon->getAssetsUrl('focuspoint.min.js'));
         rex_extension::register('MEDIA_DETAIL_SIDEBAR', 'focuspoint::show_sidebar');
-        rex_extension::register('METAINFO_CUSTOM_FIELD', 'focuspoint::customfield' );
+        rex_extension::register('METAINFO_CUSTOM_FIELD', 'focuspoint::customfield');
     }
 
     /**
      *  page=metainfo/articles
      *  page=metainfo/categories
-     *  page=metainfo/clangs
+     *  page=metainfo/clangs.
      *
      *  Auswahl des Metainfo-Datentyp "focuspoint (AddOn)" ausblenden da nur für Medien relevant
-     * 
+     *
      *  @return void
      */
-    static public function metainfoDefault()
+    public static function metainfoDefault()
     {
-        if( rex_request('func', 'string') != 'delete' )
-        {
-            rex_extension::register( 'REX_FORM_GET', function( rex_extension_point $ep ){
+        if ('delete' != rex_request('func', 'string')) {
+            rex_extension::register('REX_FORM_GET', static function (rex_extension_point $ep) {
                 try {
                     // provide access to the form-elements
-                    $formReflection = new focuspoint_reflection( $ep->getSubject() );
-                    $fieldset = $formReflection->getPropertyValue( 'fieldset' );
+                    $formReflection = new focuspoint_reflection($ep->getSubject());
+                    $fieldset = $formReflection->getPropertyValue('fieldset');
                     // search the type-select
-                    $typeid = $formReflection->executeMethod ( 'getElement', [$fieldset,'type_id'] );
-                    $typeidReflection = new focuspoint_reflection( $typeid );
+                    $typeid = $formReflection->executeMethod('getElement', [$fieldset, 'type_id']);
+                    $typeidReflection = new focuspoint_reflection($typeid);
                     // get access to the internal REX_SELECT-element
-                    $selectReflection = new focuspoint_reflection( $typeidReflection->getPropertyValue('select') );
+                    $selectReflection = new focuspoint_reflection($typeidReflection->getPropertyValue('select'));
                     $options = $selectReflection->getPropertyValue('options');
-                    foreach( $options[0][0] as $i=>$o ){
-                        if( $o[0] != rex_effect_abstract_focuspoint::META_FIELD_TYPE ) continue;
-                        array_splice( $options[0][0], $i, 1, [] );
-                        $selectReflection->setPropertyValue( 'options',$options );
-                        $selectReflection->setPropertyValue( 'optCount',$selectReflection->getPropertyValue('optCount') - 1 );
+                    foreach ($options[0][0] as $i => $o) {
+                        if (rex_effect_abstract_focuspoint::META_FIELD_TYPE != $o[0]) {
+                            continue;
+                        }
+                        array_splice($options[0][0], $i, 1, []);
+                        $selectReflection->setPropertyValue('options', $options);
+                        $selectReflection->setPropertyValue('optCount', $selectReflection->getPropertyValue('optCount') - 1);
                         return;
                     }
-                } catch (\ReflectionException $e) {
+                } catch (ReflectionException $e) {
                     return;
                 }
             });
@@ -76,7 +89,7 @@ class focuspoint_boot {
     }
 
     /**
-     *  page=metainfo/media
+     *  page=metainfo/media.
      *
      *  1) Metafelder werden in Media-Manager-Typen bzw. den eingebundenen Focuspunkt-Effekten
      *     referenziert. Sofern noch Effekte ein Focuspunkt-Metafeld nutzen, darf es nicht
@@ -86,19 +99,17 @@ class focuspoint_boot {
      *     entsprechenden Felder gesperrt, gelöscht oder begrenzt. (per JS)
      *     Gilt auch für Fokuspunkt-Felder, die bereits in Effekten/Typen des MM genutzt werden.
      *  3) Liste: In der Liste der Metafelder wird ebenfalls das Default-Feld gegen Löschen gesperrt
-     * 
+     *
      *  @return void
      */
-    static public function metainfoMedia()
+    public static function metainfoMedia()
     {
         // prevent deletion of meta-fields still in use by effects
-        if( rex_request('func', 'string') == 'delete' )
-        {
-            rex_extension::register( 'PACKAGES_INCLUDED', function( rex_extension_point $ep ){
-                if( $result = focuspoint::metafield_is_in_use( rex_request('field_id', 'int', 0) ) )
-                {
+        if ('delete' == rex_request('func', 'string')) {
+            rex_extension::register('PACKAGES_INCLUDED', static function (rex_extension_point $ep) {
+                if ($result = focuspoint::metafield_is_in_use(rex_request('field_id', 'int', 0))) {
                     $_REQUEST['func'] = '';
-                    rex_extension::register('PAGE_TITLE_SHOWN', function(rex_extension_point $ep) use ($result) {
+                    rex_extension::register('PAGE_TITLE_SHOWN', static function (rex_extension_point $ep) use ($result) {
                         $ep->setSubject(rex_view::error($result) . $ep->getSubject());
                     });
                 }
@@ -106,148 +117,148 @@ class focuspoint_boot {
         }
 
         // limit changing the default-focuspoint-metafield and fields in use: fieldname, fieldtype, no delete
-        if( rex_request('func', 'string') == 'edit' )
-        {
-            rex_extension::register( 'REX_FORM_GET', function( rex_extension_point $ep ){
+        if ('edit' == rex_request('func', 'string')) {
+            rex_extension::register('REX_FORM_GET', static function (rex_extension_point $ep) {
                 $form = $ep->getSubject();
-                $fpMetafields = focuspoint::getMetafieldList( );
+                $fpMetafields = focuspoint::getMetafieldList();
                 $field_id = rex_request('field_id', 'int');
-                if( array_key_exists( $field_id, $fpMetafields ) ) {
-                    $fpField = $fpMetafields[ $field_id ];
+                if (array_key_exists($field_id, $fpMetafields)) {
+                    $fpField = $fpMetafields[$field_id];
                     $message = '';
 
                     try {
                         // provide access to the form-elements
-                        $formReflection = new focuspoint_reflection( $ep->getSubject() );
-                        $fieldset = $formReflection->getPropertyValue( 'fieldset' );
-                        $elements = $formReflection->getPropertyValue( 'elements' );
+                        $formReflection = new focuspoint_reflection($ep->getSubject());
+                        $fieldset = $formReflection->getPropertyValue('fieldset');
+                        $elements = $formReflection->getPropertyValue('elements');
                         $fselements = $elements[$fieldset] ?? [];
 
                         // the default-field is not restrictable to mediapool-categories
-                        if( $fpField == rex_effect_abstract_focuspoint::MED_DEFAULT ) {
-                            $message .= rex_i18n::msg('focuspoint_edit_msg_inuse2',$fpField).'<br>';
+                        if (rex_effect_abstract_focuspoint::MED_DEFAULT == $fpField) {
+                            $message .= rex_i18n::msg('focuspoint_edit_msg_inuse2', $fpField) . '<br>';
                         }
                         // focuspoint-fields in use will get restrictions
-                        if ( $effects=focuspoint::getFocuspointMetafieldInUse( $fpField ) ) {
-                             $message .= rex_i18n::msg('focuspoint_edit_msg_inuse1', $fpField) .
-                                '<br>' . focuspoint::getFocuspointEffectsInUseMessage( $effects );
+                        if ($effects = focuspoint::getFocuspointMetafieldInUse($fpField)) {
+                            $message .= rex_i18n::msg('focuspoint_edit_msg_inuse1', $fpField) .
+                               '<br>' . focuspoint::getFocuspointEffectsInUseMessage($effects);
                         }
-                        if( $message ) {
-                            $message .= rex_i18n::msg('focuspoint_edit_msg_inuse3',rex_i18n::msg('minfo_field_label_name'),rex_i18n::msg('minfo_field_label_type'));
-                            echo rex_view::info('<u><b>'.rex_i18n::msg('focuspoint_doc').'</b></u><br>'.$message) . "\n";
-                            foreach( $fselements as $k=>$e ) {
-                                if( $e->getFieldName() == 'name' ) {
+                        if ($message) {
+                            $message .= rex_i18n::msg('focuspoint_edit_msg_inuse3', rex_i18n::msg('minfo_field_label_name'), rex_i18n::msg('minfo_field_label_type'));
+                            echo rex_view::info('<u><b>' . rex_i18n::msg('focuspoint_doc') . '</b></u><br>' . $message) . "\n";
+                            foreach ($fselements as $k => $e) {
+                                if ('name' == $e->getFieldName()) {
                                     // prevent the name from being changed by turning the field in a hidden one.
                                     // Don´t use type=hidden due to rex_form-behavior
-                                    $e->setPrefix( '<p class="form-control-static">'.$form->stripPrefix($e->getValue()).'</p>' );
-                                    $e->setAttribute('class','hidden');
+                                    $e->setPrefix('<p class="form-control-static">' . $form->stripPrefix($e->getValue()) . '</p>');
+                                    $e->setAttribute('class', 'hidden');
                                     continue;
                                 }
-                                if( $e->getFieldName() == 'type_id' ) {
+                                if ('type_id' == $e->getFieldName()) {
                                     // replace by a simple hidden input to preserve the value
                                     // Don´t use type=hidden due to rex_form-behavior
-                                    $x = $form->addInputField( 'input','type_id',null,[],false );
-                                    $x->setLabel( $e->getLabel() );
-                                    $x->setPrefix( '<p class="form-control-static">'.rex_effect_abstract_focuspoint::META_FIELD_TYPE.'</p>' );
-                                    $x->setAttribute( 'class','hidden' );
+                                    $x = $form->addInputField('input', 'type_id', null, [], false);
+                                    $x->setLabel($e->getLabel());
+                                    $x->setPrefix('<p class="form-control-static">' . rex_effect_abstract_focuspoint::META_FIELD_TYPE . '</p>');
+                                    $x->setAttribute('class', 'hidden');
                                     $fselements[$k] = $x;
                                     continue;
                                 }
-                                if( get_class($e) == 'rex_form_control_element' ) {
+                                if ('rex_form_control_element' == $e::class) {
                                     // don´t delete the default-field or fields in use
                                     // so remove the delete-button
                                     $controlReflection = new focuspoint_reflection($e);
-                                    $controlReflection->setPropertyValue( 'deleteElement',null );
+                                    $controlReflection->setPropertyValue('deleteElement', null);
                                     continue;
                                 }
                             }
                         }
                         $elements[$fieldset] = $fselements;
-                        $formReflection->setPropertyValue( 'elements',$elements );
-                    } catch (\ReflectionException $e) {
+                        $formReflection->setPropertyValue('elements', $elements);
+                    } catch (ReflectionException $e) {
                         return;
                     }
                 }
             });
         }
         // don´t remove the default-Metafield from the list,
-        rex_extension::register( 'REX_LIST_GET', function( rex_extension_point $ep ){
+        rex_extension::register('REX_LIST_GET', static function (rex_extension_point $ep) {
             $list = $ep->getSubject();
-# Erkenntnis aus rexstan: $effectsInUse wird in der custom-function nicht (mehr) benutzt.
-# Erst mal als Kommentar im Code belassen
-#            $effectsInUse = focuspoint::getFocuspointEffectsInUse();
-#            $list->setColumnFormat('delete', 'custom', function ($params) use($effectsInUse) {
-            $list->setColumnFormat('delete', 'custom', function ($params) {
+            // Erkenntnis aus rexstan: $effectsInUse wird in der custom-function nicht (mehr) benutzt.
+            // Erst mal als Kommentar im Code belassen
+            //            $effectsInUse = focuspoint::getFocuspointEffectsInUse();
+            //            $list->setColumnFormat('delete', 'custom', function ($params) use($effectsInUse) {
+            $list->setColumnFormat('delete', 'custom', static function ($params) {
                 $list = $params['list'];
-                if( $list->getValue('name') == rex_effect_abstract_focuspoint::MED_DEFAULT ) {
+                if (rex_effect_abstract_focuspoint::MED_DEFAULT == $list->getValue('name')) {
                     return '<small class="text-muted">' . rex_i18n::msg('focuspoint_doc') . '</small>';
                 }
-                # planned with V3.0 because it is a breaking change:
-                #   show detailed in-use-information insteag of a "blocked"
-                # if( $inUse = focuspoint::metafield_is_in_use( $list->getValue('id') ) ) return '<small class="text-muted">'.$inUse.'</small>';
-                if( $presetValue = $params['params'][0] ) return $list->formatValue('', $presetValue, false, 'delete');
+                // planned with V3.0 because it is a breaking change:
+                //   show detailed in-use-information insteag of a "blocked"
+                // if( $inUse = focuspoint::metafield_is_in_use( $list->getValue('id') ) ) return '<small class="text-muted">'.$inUse.'</small>';
+                if ($presetValue = $params['params'][0]) {
+                    return $list->formatValue('', $presetValue, false, 'delete');
+                }
                 return $list->getColumnLink('delete', $list->getValue('delete'));
             }, [$list->getColumnFormat('delete')]);
         });
     }
 
     /**
-     *  page=media_manager/types
+     *  page=media_manager/types.
      *
      *  Verhindert in der Liste der verfügbaren Media-Manager-Typen bzw. im Edit-Formular,
      *  dass der von Focuspoint selbst benötigte Media-Manager-Typ "rex_effect_abstract_focuspoint::MM_TYPE"
      *  gelöscht oder sein Name verändert wird.
-     * 
+     *
      *  @return void
      */
-    static public function media_managerTypes()
+    public static function media_managerTypes()
     {
-        if( rex_request('effects', 'int') != 1 ) {
+        if (1 != rex_request('effects', 'int')) {
 
             // Listenansicht anpassen und hier schon unzulässige Button deaktivieren
-            rex_extension::register( 'REX_LIST_GET', function( rex_extension_point $ep ){
+            rex_extension::register('REX_LIST_GET', static function (rex_extension_point $ep) {
                 $list = $ep->getSubject();
-                $list->setColumnFormat('deleteType', 'custom', function($params){
+                $list->setColumnFormat('deleteType', 'custom', static function ($params) {
                     $list = $params['list'];
-                    if( $list->getValue('name') == rex_effect_abstract_focuspoint::MM_TYPE ) {
+                    if (rex_effect_abstract_focuspoint::MM_TYPE == $list->getValue('name')) {
                         return '<small class="text-muted">' . rex_i18n::msg('focuspoint_doc') . '</small>';
                     }
                     $field = $params['field'];
-                    if( $presetValue = $params['params'][0] ) {
+                    if ($presetValue = $params['params'][0]) {
                         return $list->formatValue($list->getValue($field), $presetValue, false, $field);
                     }
                     return $list->getColumnLink($field, $list->getValue($field));
                 }, [$list->getColumnFormat('deleteType')]);
             });
 
-
         }
 
         // Verhindert beim Editieren des Support-Media-Types im Medienpool dass der Name überschrieben wird.
         // Außerdem darf der Eintrag nicht gelöscht werden, daher muss der Löschbutton unterdrückt werden.
-        if( 'edit' == rex_request('func', 'string') ) {
+        if ('edit' == rex_request('func', 'string')) {
 
-            rex_extension::register( 'REX_FORM_CONTROL_FIELDS', function( rex_extension_point $ep ){
+            rex_extension::register('REX_FORM_CONTROL_FIELDS', static function (rex_extension_point $ep) {
                 $sql = rex_sql::factory();
                 $qry = 'SELECT * FROM ' . rex::getTable('media_manager_type') . ' WHERE id=? and name=?';
-                $sql->setQuery($qry, [rex_request('type_id', 'int'),rex_effect_abstract_focuspoint::MM_TYPE]);
-                if( $sql->getRows() ) {
+                $sql->setQuery($qry, [rex_request('type_id', 'int'), rex_effect_abstract_focuspoint::MM_TYPE]);
+                if ($sql->getRows()) {
                     $cf = $ep->getSubject();
                     $cf['delete'] = '';
-                    $ep->setSubject( $cf );
-                    rex_extension::register( 'REX_FORM_GET', function( rex_extension_point $ep ){
+                    $ep->setSubject($cf);
+                    rex_extension::register('REX_FORM_GET', static function (rex_extension_point $ep) {
                         $form = $ep->getSubject();
                         // provide access to the form-elements
-                        $formReflection = new focuspoint_reflection( $form );
-                        $fieldset = $formReflection->getPropertyValue( 'fieldset' );
-                        $elements = $formReflection->getPropertyValue( 'elements' );
+                        $formReflection = new focuspoint_reflection($form);
+                        $fieldset = $formReflection->getPropertyValue('fieldset');
+                        $elements = $formReflection->getPropertyValue('elements');
                         $fselements = $elements[$fieldset] ?? [];
-                        foreach( $fselements as $k=>$e ) {
-                            if( 'name' == $e->getFieldName() ) {
+                        foreach ($fselements as $k => $e) {
+                            if ('name' == $e->getFieldName()) {
                                 // prevent the name from being changed by turning the field in a hidden one.
                                 // Don´t use type=hidden due to rex_form-behavior
-                                $e->setPrefix( '<p class="form-control-static">'.$e->getValue().'</p>' );
-                                $e->setAttribute('class','hidden');
+                                $e->setPrefix('<p class="form-control-static">' . $e->getValue() . '</p>');
+                                $e->setAttribute('class', 'hidden');
                                 break;
                             }
                         }
@@ -258,36 +269,34 @@ class focuspoint_boot {
         }
 
         // Falls doch ein "delete" ankommt und den Default-Type betrifft: abblocken
-        if( 'delete' == rex_request('func', 'string') ) {
+        if ('delete' == rex_request('func', 'string')) {
             $sql = rex_sql::factory();
             $qry = 'SELECT * FROM ' . rex::getTable('media_manager_type') . ' WHERE id=? and name=?';
-            $sql->setQuery($qry, [rex_request('type_id', 'int'),rex_effect_abstract_focuspoint::MM_TYPE]);
-            if( $sql->getRows() ) {
+            $sql->setQuery($qry, [rex_request('type_id', 'int'), rex_effect_abstract_focuspoint::MM_TYPE]);
+            if ($sql->getRows()) {
                 $_REQUEST['func'] = '';
-                rex_extension::register('PAGE_TITLE_SHOWN', function(rex_extension_point $ep) {
-                    $result = rex_i18n::msg('focuspoint_isinuse_dontdeletedefault',rex_effect_abstract_focuspoint::MM_TYPE);
+                rex_extension::register('PAGE_TITLE_SHOWN', static function (rex_extension_point $ep) {
+                    $result = rex_i18n::msg('focuspoint_isinuse_dontdeletedefault', rex_effect_abstract_focuspoint::MM_TYPE);
                     $ep->setSubject(rex_view::error($result) . $ep->getSubject());
                 });
-            };
+            }
         }
     }
 
     /**
-     *  page=packages
+     *  page=packages.
      *
      *  leitet auf einen spezialisierten API-Handler um.
-     * 
+     *
      *  @param rex_addon $fpAddon
      *  @return void
      */
-    static public function packages( $fpAddon )
+    public static function packages($fpAddon)
     {
-        if( rex_request('package', 'string') == $fpAddon->getName()
+        if (rex_request('package', 'string') == $fpAddon->getName()
             && isset($_REQUEST['rex-api-call'])
-            && $_REQUEST['rex-api-call'] == 'package' )
-        {
+            && 'package' == $_REQUEST['rex-api-call']) {
             $_REQUEST['rex-api-call'] = 'focuspoint_package';
         }
     }
-
 }

--- a/lib/focuspoint_media.php
+++ b/lib/focuspoint_media.php
@@ -16,7 +16,7 @@
  *  Umgang mit Medien, deren Darstellung auf Fokuspunkten basiert.
  */
 
-namespace FriendsOfREDAXO\focuspoint;
+namespace FriendsOfRedaxo\focuspoint;
 
 use rex_effect_abstract_focuspoint;
 use rex_media;

--- a/lib/focuspoint_media.php
+++ b/lib/focuspoint_media.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.0.2
+ *  @version     4.1.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -14,12 +14,15 @@
  *
  *  Die Klasse "focuspoint_media" ist von "rex_media" abgeleitet und erleichetrt den
  *  Umgang mit Medien, deren Darstellung auf Fokuspunkten basiert.
- *
  */
+
+namespace FriendsOfREDAXO\focuspoint;
+
+use rex_effect_abstract_focuspoint;
+use rex_media;
 
 class focuspoint_media extends rex_media
 {
-
     /**
      *  Gibt die Bildinstanz zurück und prüft dabei ab, ob es ein Bild ist (isImage).
      *
@@ -28,17 +31,16 @@ class focuspoint_media extends rex_media
     public static function get($name)
     {
         $media = parent::get($name);
-        if( $media ) {
-            if( !$media->isImage() ) {
+        if ($media) {
+            if (!$media->isImage()) {
                 $media = null;
             }
         }
         return $media;
     }
 
-
     /**
-     *  Ermittelt die Fokuspunkt-Koordinaten des Bildes
+     *  Ermittelt die Fokuspunkt-Koordinaten des Bildes.
      *
      *  Liefert ein Koordinatenpaar (Prozentwert) aus dem angegebenen Metafeld oder (default) aus
      *  dem Feld "med_focuspoint". Ist das feld leer oder hat einen formal ungültigen wert, wird
@@ -55,35 +57,37 @@ class focuspoint_media extends rex_media
      *                                          default: med_focuspoint
      *  @param  array<mixed>       $default    Default-Koordinaten falls das Metafeld leer oder ungültig ist.
      *                                          Wenn $default fehlt: 50,50
-     *  @param  array<mixed>|bool   $wh         Array [breite,höhe] mit den absoluten Referenzwerten, auf die
+     *  @param  array<mixed>|bool   $wh         array [breite,höhe] mit den absoluten Referenzwerten, auf die
      *                                          sich die Prozentwerte der Koordinaten beziehen, oder True für
-     *                                          [bildbreite,bildhöhe].
+     *                                          [bildbreite,bildhöhe]
      *
      *  @return array<float>                    [x,y] als Koordinaten-Array
      */
-    function getFocus( $metafield = null, array $default = null, $wh=false )
+    public function getFocus($metafield = null, ?array $default = null, $wh = false)
     {
         // read the field
-        if(  $metafield == null ) $metafield = rex_effect_abstract_focuspoint::MED_DEFAULT;
-        $xy = (string) $this->getValue( (string)$metafield );
+        if (null == $metafield) {
+            $metafield = rex_effect_abstract_focuspoint::MED_DEFAULT;
+        }
+        $xy = (string) $this->getValue((string) $metafield);
 
-        $fp = rex_effect_abstract_focuspoint::str2fp( $xy );
-        if( $fp === false )
-        {
-            $fp = $default ? $default : rex_effect_abstract_focuspoint::$mitte;
+        $fp = rex_effect_abstract_focuspoint::str2fp($xy);
+        if (false === $fp) {
+            $fp = $default ?: rex_effect_abstract_focuspoint::$mitte;
         }
 
-        if( $wh !== false )
-        {
-            if( $wh === true ) $wh = [ $this->getWidth(), $this->getHeight() ];
-            $fp = rex_effect_abstract_focuspoint::rel2px( $fp, $wh );
+        if (false !== $wh) {
+            if (true === $wh) {
+                $wh = [$this->getWidth(), $this->getHeight()];
+            }
+            $fp = rex_effect_abstract_focuspoint::rel2px($fp, $wh);
         }
 
         return $fp;
     }
 
     /**
-     *  Ermittelt, ob ein Fokuspunkt gesetzt ist
+     *  Ermittelt, ob ein Fokuspunkt gesetzt ist.
      *
      *  Liefert true zurück, wenn
      *  (1) das angegebene Fokuspunkt-Metafeld existiert und
@@ -92,14 +96,16 @@ class focuspoint_media extends rex_media
      *  @param  string     $metafield   Metafeld, aus dem die Koordinaten entnommen werden.
      *                                  default: med_focuspoint
      *
-     *  @return bool                        
+     *  @return bool
      */
-    function hasFocus( $metafield = null )
+    public function hasFocus($metafield = null)
     {
         // read the field
-        if(  $metafield == null ) $metafield = rex_effect_abstract_focuspoint::MED_DEFAULT;
-        $xy = (string) $this->getValue( (string)$metafield );
+        if (null == $metafield) {
+            $metafield = rex_effect_abstract_focuspoint::MED_DEFAULT;
+        }
+        $xy = (string) $this->getValue((string) $metafield);
         // check for a valid entry
-        return rex_effect_abstract_focuspoint::str2fp( $xy ) !== false;
+        return false !== rex_effect_abstract_focuspoint::str2fp($xy);
     }
 }

--- a/lib/focuspoint_reflection.php
+++ b/lib/focuspoint_reflection.php
@@ -18,7 +18,7 @@
  *  HANDLE WITH CARE!
  */
 
-namespace FriendsOfREDAXO\focuspoint;
+namespace FriendsOfRedaxo\focuspoint;
 
 use ReflectionClass;
 

--- a/lib/focuspoint_reflection.php
+++ b/lib/focuspoint_reflection.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.0.2
+ *  @version     4.1.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -16,22 +16,26 @@
  *  in der Klasse ansonsten nicht zugänglich sind (private oder protected)
  *
  *  HANDLE WITH CARE!
- *
  */
+
+namespace FriendsOfREDAXO\focuspoint;
+
+use ReflectionClass;
 
 // rexstan meldet: "Class focuspoint_reflection extends generic class ReflectionClass but does not specify its types: T"
 // Warum?? Einfach ignorieren
-class focuspoint_reflection extends ReflectionClass {
-
+class focuspoint_reflection extends ReflectionClass
+{
     /** @var object */
-    public $obj = null;
+    public $obj;
 
     /**
      *  @param object $obj
      *  @return void
      */
-    function __construct( $obj ) {
-        parent::__construct( $obj );
+    public function __construct($obj)
+    {
+        parent::__construct($obj);
         $this->obj = $obj;
     }
 
@@ -40,8 +44,9 @@ class focuspoint_reflection extends ReflectionClass {
      *  @param array<mixed> $params
      *  @return mixed
      */
-    function executeMethod ($method, array $params){
-        $method = $this->getMethod( $method );
+    public function executeMethod($method, array $params)
+    {
+        $method = $this->getMethod($method);
         $method->setAccessible(true);
         return $method->invokeArgs($this->obj, $params);
     }
@@ -50,10 +55,11 @@ class focuspoint_reflection extends ReflectionClass {
      *  @param string $prop
      *  @return mixed
      */
-    function getPropertyValue ( $prop ) {
+    public function getPropertyValue($prop)
+    {
         $property = $this->getProperty($prop);
         $property->setAccessible(true);
-        return $property->getValue( $this->obj );
+        return $property->getValue($this->obj);
     }
 
     /**
@@ -61,9 +67,10 @@ class focuspoint_reflection extends ReflectionClass {
      *  @param mixed $value
      *  @return void
      */
-    function setPropertyValue ( $prop, $value ) {
+    public function setPropertyValue($prop, $value)
+    {
         $property = $this->getProperty($prop);
         $property->setAccessible(true);
-        $property->setValue( $this->obj, $value );
+        $property->setValue($this->obj, $value);
     }
 }

--- a/lib/no_namespace/focuspoint.php
+++ b/lib/no_namespace/focuspoint.php
@@ -16,9 +16,10 @@
  * auf diesem Wege weiterhin bereitgestellt. Diese Klasse fällt mit Version 5.0.0 weg, nachdem
  * Redaxo auf Composer als Installer umgestellt wurde.
  *
- * @deprecated 5.0.0 Aufrufe auf "FriendsOfREDAXO\focuspoint\focuspoint" (Namespace) umstellen
+ * @deprecated 5.0.0 Aufrufe auf "FriendsOfRedaxo\focuspoint\focuspoint" (Namespace) umstellen
+ * @see https://github.com/orgs/FriendsOfREDAXO/discussions/40
  */
 
-class focuspoint extends FriendsOfREDAXO\focuspoint\focuspoint
+class focuspoint extends FriendsOfRedaxo\focuspoint\focuspoint
 {
 }

--- a/lib/no_namespace/focuspoint.php
+++ b/lib/no_namespace/focuspoint.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ *  This file is part of the REDAXO-AddOn "focuspoint".
+ *
+ *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
+ *  @version     4.1.0
+ *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  ------------------------------------------------------------------------------------------------
+ *
+ * Mit Version 4.1 wird das Addon auf namespaces umgestellt. Für den Übergang wird die alte Klasse
+ * auf diesem Wege weiterhin bereitgestellt. Diese Klasse fällt mit Version 5.0.0 weg, nachdem
+ * Redaxo auf Composer als Installer umgestellt wurde.
+ *
+ * @deprecated 5.0.0 Aufrufe auf "FriendsOfREDAXO\focuspoint\focuspoint" (Namespace) umstellen
+ */
+
+class focuspoint extends FriendsOfREDAXO\focuspoint\focuspoint
+{
+}

--- a/lib/no_namespace/focuspoint_boot.php
+++ b/lib/no_namespace/focuspoint_boot.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ *  This file is part of the REDAXO-AddOn "focuspoint".
+ *
+ *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
+ *  @version     4.1.0
+ *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  ------------------------------------------------------------------------------------------------
+ *
+ * Mit Version 4.1 wird das Addon auf namespaces umgestellt. Für den Übergang wird die alte Klasse
+ * auf diesem Wege weiterhin bereitgestellt. Diese Klasse fällt mit Version 5.0.0 weg, nachdem
+ * Redaxo auf Composer als Installer umgestellt wurde.
+ *
+ * @deprecated 5.0.0 Aufrufe auf "FriendsOfREDAXO\focuspoint\focuspoint_boot" (Namespace) umstellen
+ * @see https://github.com/orgs/FriendsOfREDAXO/discussions/40
+ */
+
+class focuspoint_boot extends FriendsOfREDAXO\focuspoint\focuspoint_boot
+{
+}

--- a/lib/no_namespace/focuspoint_boot.php
+++ b/lib/no_namespace/focuspoint_boot.php
@@ -16,10 +16,10 @@
  * auf diesem Wege weiterhin bereitgestellt. Diese Klasse fällt mit Version 5.0.0 weg, nachdem
  * Redaxo auf Composer als Installer umgestellt wurde.
  *
- * @deprecated 5.0.0 Aufrufe auf "FriendsOfREDAXO\focuspoint\focuspoint_boot" (Namespace) umstellen
+ * @deprecated 5.0.0 Aufrufe auf "FriendsOfRedaxo\focuspoint\focuspoint_boot" (Namespace) umstellen
  * @see https://github.com/orgs/FriendsOfREDAXO/discussions/40
  */
 
-class focuspoint_boot extends FriendsOfREDAXO\focuspoint\focuspoint_boot
+class focuspoint_boot extends FriendsOfRedaxo\focuspoint\focuspoint_boot
 {
 }

--- a/lib/no_namespace/focuspoint_media.php
+++ b/lib/no_namespace/focuspoint_media.php
@@ -16,9 +16,10 @@
  * auf diesem Wege weiterhin bereitgestellt. Diese Klasse fällt mit Version 5.0.0 weg, nachdem
  * Redaxo auf Composer als Installer umgestellt wurde.
  *
- * @deprecated 5.0.0 Aufrufe auf "FriendsOfREDAXO\focuspoint\focuspoint_media" (Namespace) umstellen
+ * @deprecated 5.0.0 Aufrufe auf "FriendsOfRedaxo\focuspoint\focuspoint_media" (Namespace) umstellen
+ * @see https://github.com/orgs/FriendsOfREDAXO/discussions/40
  */
 
-class focuspoint_media extends FriendsOfREDAXO\focuspoint\focuspoint_media
+class focuspoint_media extends FriendsOfRedaxo\focuspoint\focuspoint_media
 {
 }

--- a/lib/no_namespace/focuspoint_media.php
+++ b/lib/no_namespace/focuspoint_media.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ *  This file is part of the REDAXO-AddOn "focuspoint".
+ *
+ *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
+ *  @version     4.1.0
+ *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  ------------------------------------------------------------------------------------------------
+ *
+ * Mit Version 4.1 wird das Addon auf namespaces umgestellt. Für den Übergang wird die alte Klasse
+ * auf diesem Wege weiterhin bereitgestellt. Diese Klasse fällt mit Version 5.0.0 weg, nachdem
+ * Redaxo auf Composer als Installer umgestellt wurde.
+ *
+ * @deprecated 5.0.0 Aufrufe auf "FriendsOfREDAXO\focuspoint\focuspoint_media" (Namespace) umstellen
+ */
+
+class focuspoint_media extends FriendsOfREDAXO\focuspoint\focuspoint_media
+{
+}

--- a/lib/no_namespace/focuspoint_reflection.php
+++ b/lib/no_namespace/focuspoint_reflection.php
@@ -16,9 +16,10 @@
  * auf diesem Wege weiterhin bereitgestellt. Diese Klasse fällt mit Version 5.0.0 weg, nachdem
  * Redaxo auf Composer als Installer umgestellt wurde.
  *
- * @deprecated 5.0.0 Aufrufe auf "FriendsOfREDAXO\focuspoint\focuspoint_reflection" (Namespace) umstellen
+ * @deprecated 5.0.0 Aufrufe auf "FriendsOfRedaxo\focuspoint\focuspoint_reflection" (Namespace) umstellen
+ * @see https://github.com/orgs/FriendsOfREDAXO/discussions/40
  */
 
-class focuspoint_reflection extends FriendsOfREDAXO\focuspoint\focuspoint_reflection
+class focuspoint_reflection extends FriendsOfRedaxo\focuspoint\focuspoint_reflection
 {
 }

--- a/lib/no_namespace/focuspoint_reflection.php
+++ b/lib/no_namespace/focuspoint_reflection.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ *  This file is part of the REDAXO-AddOn "focuspoint".
+ *
+ *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
+ *  @version     4.1.0
+ *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  ------------------------------------------------------------------------------------------------
+ *
+ * Mit Version 4.1 wird das Addon auf namespaces umgestellt. Für den Übergang wird die alte Klasse
+ * auf diesem Wege weiterhin bereitgestellt. Diese Klasse fällt mit Version 5.0.0 weg, nachdem
+ * Redaxo auf Composer als Installer umgestellt wurde.
+ *
+ * @deprecated 5.0.0 Aufrufe auf "FriendsOfREDAXO\focuspoint\focuspoint_reflection" (Namespace) umstellen
+ */
+
+class focuspoint_reflection extends FriendsOfREDAXO\focuspoint\focuspoint_reflection
+{
+}

--- a/lib/package_api.php
+++ b/lib/package_api.php
@@ -31,60 +31,61 @@
  *               &file=      Name der Mediendatei
  *               &type=      Name des MM-Effektes
  *               &xy=        Fokuspunkt numerisch (0.0,0.0 bis 100.1,100.0)
- *
  */
 
- class rex_api_focuspoint_package extends rex_api_package {
+class rex_api_focuspoint_package extends rex_api_package
+{
+    /**
+     *  Ausführende Funktion des rex_api_call "focuspoint".
+     *
+     *  prüft die Request-Parameter, initiiert die Bilderstellung und sendet das Bild an die Browser
+     */
+    public function execute()
+    {
+        $function = rex_request('function', 'string');
+        if (!in_array($function, ['install', 'uninstall', 'activate', 'deactivate', 'delete'])) {
+            throw new rex_api_exception('Unknown package function "' . $function . '"!');
+        }
+        $packageId = rex_request('package', 'string');
+        $package = rex_package::get($packageId);
+        if ('uninstall' == $function && !$package->isInstalled()
+            || 'activate' == $function && $package->isAvailable()
+            || 'deactivate' == $function && !$package->isAvailable()
+            || 'delete' == $function && !rex_package::exists($packageId)
+        ) {
+            return new rex_api_result(true);
+        }
 
-     /**
-      *  Ausführende Funktion des rex_api_call "focuspoint"
-      *
-      *  prüft die Request-Parameter, initiiert die Bilderstellung und sendet das Bild an die Browser
-      */
-      public function execute()
-      {
-          $function = rex_request('function', 'string');
-          if (!in_array($function, ['install', 'uninstall', 'activate', 'deactivate', 'delete'])) {
-              throw new rex_api_exception('Unknown package function "' . $function . '"!');
-          }
-          $packageId = rex_request('package', 'string');
-          $package = rex_package::get($packageId);
-          if ($function == 'uninstall' && !$package->isInstalled()
-              || $function == 'activate' && $package->isAvailable()
-              || $function == 'deactivate' && !$package->isAvailable()
-              || $function == 'delete' && !rex_package::exists($packageId)
-          ) {
-              return new rex_api_result(true);
-          }
+        if ($package instanceof rex_null_package) {
+            throw new rex_api_exception('Package "' . $packageId . '" doesn\'t exists!');
+        }
+        $reinstall = 'install' === $function && $package->isInstalled();
+        /**
+         * Die rexstan-Fehlermeldung beruht vermutlich auf Bezügen zu rex_package; ist aber hier nicht lösbar.
+         * @phpstan-ignore-next-line
+         */
+        $manager = rex_package_manager::factory($package);
+        try {
+            $package->includeFile('precheck.php', ['request' => ($reinstall ? 'reinstall' : $function)]);
+            $message = ''; // $package->getProperty('precheckmsg', '');
+            $success = true; // $message == '';
+        } catch (rex_functional_exception $e) {
+            $message = $e->getMessage();
+            $success = false;
+        }
+        if ($success) {
+            $success = $manager->$function();
+            $message = $manager->getMessage();
+        }
+        $result = new rex_api_result($success, $message);
+        if ($success && !$reinstall) {
+            $result->setRequiresReboot(true);
+        }
+        return $result;
+    }
 
-          if ($package instanceof rex_null_package) {
-              throw new rex_api_exception('Package "' . $packageId . '" doesn\'t exists!');
-          }
-          $reinstall = 'install' === $function && $package->isInstalled();
-          // Die rexstan-Fehlermeldung beruht vermutlich auf Bezügen zu rex_package; ist aber hier nicht lösbar. 
-          // @phpstan-ignore-next-line
-          $manager = rex_package_manager::factory($package);
-          try {
-              $package->includeFile('precheck.php', [ 'request' => ($reinstall ? 'reinstall' : $function) ] );
-              $message = ''; #$package->getProperty('precheckmsg', '');
-              $success = true; # $message == '';
-          } catch (rex_functional_exception $e) {
-              $message = $e->getMessage();
-              $success = false;
-          }
-          if( $success ) {
-              $success = $manager->$function();
-              $message = $manager->getMessage();
-          }
-          $result = new rex_api_result($success, $message);
-          if ($success && !$reinstall) {
-              $result->setRequiresReboot(true);
-          }
-          return $result;
-      }
-      protected function requiresCsrfProtection()
-      {
-          return false;
-      }
-
- }
+    protected function requiresCsrfProtection()
+    {
+        return false;
+    }
+}

--- a/precheck.php
+++ b/precheck.php
@@ -52,20 +52,19 @@
  *  @var string $request
  */
 
-namespace FriendsOfREDAXO\focuspoint;
+namespace FriendsOfRedaxo\focuspoint;
 
-use rex_i18n;
 use rex_functional_exception;
+use rex_i18n;
 
 $message = '';
 $header = '';
-switch ( $request )
-{
+switch ($request) {
     case 'install':
-        //noop
+        // noop
         break;
     case 'reinstall':
-        //noop
+        // noop
         break;
     case 'activate':
         $message = focuspoint::checkActivateDependencies();
@@ -85,7 +84,7 @@ switch ( $request )
         break;
 }
 
-if( $message ){
+if ($message) {
     $message = rex_i18n::rawMsg($header, $this->getName()) . "<br>$message";
-    throw new rex_functional_exception( $message );
+    throw new rex_functional_exception($message);
 }

--- a/precheck.php
+++ b/precheck.php
@@ -1,9 +1,9 @@
 <?php
 /**
- *  This file is part of the REDAXO-AddOn ".....".
+ *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.0.2
+ *  @version     4.1.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -52,6 +52,11 @@
  *  @var string $request
  */
 
+namespace FriendsOfREDAXO\focuspoint;
+
+use rex_i18n;
+use rex_functional_exception;
+
 $message = '';
 $header = '';
 switch ( $request )
@@ -79,7 +84,7 @@ switch ( $request )
         $header = 'addon_not_deleted';
         break;
 }
-dump($message);
+
 if( $message ){
     $message = rex_i18n::rawMsg($header, $this->getName()) . "<br>$message";
     throw new rex_functional_exception( $message );

--- a/uninstall.php
+++ b/uninstall.php
@@ -26,7 +26,7 @@
  *  @var rex_addon $this
  */
 
-namespace FriendsOfREDAXO\focuspoint;
+namespace FriendsOfRedaxo\focuspoint;
 
 use rex;
 use rex_effect_abstract_focuspoint;

--- a/uninstall.php
+++ b/uninstall.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.0.2
+ *  @version     4.1.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -26,34 +26,42 @@
  *  @var rex_addon $this
  */
 
+namespace FriendsOfREDAXO\focuspoint;
+
+use rex;
+use rex_effect_abstract_focuspoint;
+use rex_media_manager;
+use rex_sql;
+
+use function count;
+
 // make addon-parameters available
-include_once ( 'lib/effect_focuspoint.php' );
+include_once 'lib/effect_focuspoint.php';
 
 $sql = rex_sql::factory();
 
 // remove default-meta-field
-rex_metainfo_delete_field( rex_effect_abstract_focuspoint::MED_DEFAULT );
+rex_metainfo_delete_field(rex_effect_abstract_focuspoint::MED_DEFAULT);
 
 // remove meta-type
 $qry = 'SELECT id FROM ' . rex::getTable('metainfo_type') . ' WHERE label=:label LIMIT 1';
-$typeId = $sql->getArray( $qry, [':label' => rex_effect_abstract_focuspoint::META_FIELD_TYPE] );
+$typeId = $sql->getArray($qry, [':label' => rex_effect_abstract_focuspoint::META_FIELD_TYPE]);
 
-if( count( $typeId ) )
-{
-    rex_metainfo_delete_field_type( (int)$typeId[0]['id'] );
+if (count($typeId)) {
+    rex_metainfo_delete_field_type((int) $typeId[0]['id']);
 }
 
 // remove media-manager-type
-$sql->setQuery('select id from '.rex::getTable('media_manager_type').' where name="'.rex_effect_abstract_focuspoint::MM_TYPE.'" LIMIT 1');
-if( $sql->getRows() ) {
-    $id = $sql->getValue( 'id' );
-    $sql->setTable( rex::getTable('media_manager_type') );
-    $sql->setWhere( 'id='.$id );
+$sql->setQuery('select id from ' . rex::getTable('media_manager_type') . ' where name="' . rex_effect_abstract_focuspoint::MM_TYPE . '" LIMIT 1');
+if ($sql->getRows()) {
+    $id = $sql->getValue('id');
+    $sql->setTable(rex::getTable('media_manager_type'));
+    $sql->setWhere('id=' . $id);
     $sql->delete();
-    $sql->setTable( rex::getTable('media_manager_type_effect') );
-    $sql->setWhere( 'type_id='.$id );
+    $sql->setTable(rex::getTable('media_manager_type_effect'));
+    $sql->setWhere('type_id=' . $id);
     $sql->delete();
 }
 
 // ... delete corresponding cache files
-rex_media_manager::deleteCache( null, rex_effect_abstract_focuspoint::MM_TYPE );
+rex_media_manager::deleteCache(null, rex_effect_abstract_focuspoint::MM_TYPE);

--- a/update.php
+++ b/update.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.0.2
+ *  @version     4.1.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -18,13 +18,27 @@
  *  @var rex_addon $this
  */
 
-if (rex_string::versionCompare($this->getVersion(), '2.0', '<'))
-{
+namespace FriendsOfREDAXO\focuspoint;
+
+use Exception;
+
+use PDO;
+use rex;
+use rex_effect_abstract_focuspoint;
+use rex_i18n;
+use rex_sql;
+use rex_sql_column;
+use rex_sql_table;
+use rex_version;
+
+use function count;
+
+if (rex_version::compare($this->getVersion(), '2.0', '<')) {
     // activate .lang-files currently in a temporary directory
-    rex_i18n::addDirectory( __DIR__.'/lang' );
+    rex_i18n::addDirectory(__DIR__ . '/lang');
 
     // prerequisites, to fetch predefined strings
-    include_once( 'lib/effect_focuspoint.php' );
+    include_once 'lib/effect_focuspoint.php';
 
     $sql = rex_sql::factory();
     $sql->beginTransaction();
@@ -39,63 +53,53 @@ if (rex_string::versionCompare($this->getVersion(), '2.0', '<'))
             : rex_metainfo_add_field_type(rex_effect_abstract_focuspoint::META_FIELD_TYPE, 'string', 20);
 
     // if valid type_id add default-field
-    if( is_numeric($type_id) )
-    {
+    if (is_numeric($type_id)) {
 
         // Identify existing metafield by name and read current type_id
         $qry = 'SELECT type_id FROM ' . rex::getTable('metainfo_field') . ' WHERE name=:name LIMIT 1';
         $field = $sql->getArray($qry, [':name' => rex_effect_abstract_focuspoint::MED_DEFAULT]);
 
-        if( $field )
-        {
-            if( $field[0]['type_id'] != $type_id )
-            {
-                $message = rex_i18n::msg( 'focuspoint_install_field_exists', rex_effect_abstract_focuspoint::MED_DEFAULT,rex_effect_abstract_focuspoint::META_FIELD_TYPE );
+        if ($field) {
+            if ($field[0]['type_id'] != $type_id) {
+                $message = rex_i18n::msg('focuspoint_install_field_exists', rex_effect_abstract_focuspoint::MED_DEFAULT, rex_effect_abstract_focuspoint::META_FIELD_TYPE);
             }
-        }
-        else
-        {
+        } else {
             // field does not exist. Add field
             $result = rex_metainfo_add_field('translate:focuspoint_field_label', rex_effect_abstract_focuspoint::MED_DEFAULT, 3, '', $type_id, '', '', '', '');
-            if( $result !== true )
-            {
-                $message = rex_i18n::msg( 'focuspoint_install_field_error', rex_effect_abstract_focuspoint::MED_DEFAULT, "<strong><i>$result</i></strong>" );
+            if (true !== $result) {
+                $message = rex_i18n::msg('focuspoint_install_field_error', rex_effect_abstract_focuspoint::MED_DEFAULT, "<strong><i>$result</i></strong>");
             }
             // for unknown reason in "update.php" rex_metainfo_add_field does not add the new field to rex_media, additional measure required
             else {
                 rex_sql_table::get(rex::getTable('media'))
-                    ->ensureColumn(new rex_sql_column(rex_effect_abstract_focuspoint::MED_DEFAULT, 'varchar(20)', true, ''),'revision')
+                    ->ensureColumn(new rex_sql_column(rex_effect_abstract_focuspoint::MED_DEFAULT, 'varchar(20)', true, ''), 'revision')
                     ->ensure();
             }
         }
 
         // Field prepared
-        if( !$message )
-        {
+        if (!$message) {
 
             try {
 
                 // transfer coordinates from old data_field "med_focuspoint_data" to new default-field
 
-                $tab = rex::getTable( 'media' );
-                $qry = 'SHOW COLUMNS FROM '.$tab.' WHERE Field = "med_focuspoint_data"';
-                if( $sql->getArray( $qry) )
-                {
+                $tab = rex::getTable('media');
+                $qry = 'SHOW COLUMNS FROM ' . $tab . ' WHERE Field = "med_focuspoint_data"';
+                if ($sql->getArray($qry)) {
 
-                    $qry = 'SELECT id,med_focuspoint_data FROM '.$tab.' WHERE med_focuspoint_data > ""';
+                    $qry = 'SELECT id,med_focuspoint_data FROM ' . $tab . ' WHERE med_focuspoint_data > ""';
                     /** @var array<integer,string> $liste */
-                    $liste = $sql->getArray( $qry, [], PDO::FETCH_KEY_PAIR );
-                    foreach( $liste as $k=>$v )
-                    {
-                        if( preg_match_all( '/(?<x>[+-]?[0-1][.][0-9]{2}),(?<y>[+-]?[0-1][.][0-9]{2})/', $v, $tags ) )
-                        {
+                    $liste = $sql->getArray($qry, [], PDO::FETCH_KEY_PAIR);
+                    foreach ($liste as $k => $v) {
+                        if (preg_match_all('/(?<x>[+-]?[0-1][.][0-9]{2}),(?<y>[+-]?[0-1][.][0-9]{2})/', $v, $tags)) {
                             $x = ($tags['x'][0] + 1) * 50;
                             $y = (1 - $tags['y'][0]) * 50;
-                            $x = max( 0, min( 100,$x ) );
-                            $y = max( 0, min( 100,$y ) );
-                            $sql->setTable( $tab );
-                            $sql->setValue( rex_effect_abstract_focuspoint::MED_DEFAULT, sprintf( rex_effect_abstract_focuspoint::STRING, $x, $y ) );
-                            $sql->setWhere( 'id = :id', [':id'=>$k] );
+                            $x = max(0, min(100, $x));
+                            $y = max(0, min(100, $y));
+                            $sql->setTable($tab);
+                            $sql->setValue(rex_effect_abstract_focuspoint::MED_DEFAULT, sprintf(rex_effect_abstract_focuspoint::STRING, $x, $y));
+                            $sql->setWhere('id = :id', [':id' => $k]);
                             $sql->update();
                         }
                     }
@@ -109,115 +113,102 @@ if (rex_string::versionCompare($this->getVersion(), '2.0', '<'))
                 // update parameter-set per field "focuspoint-fit" and "focuspoint-resize" to new structure"
 
                 $tab = rex::getTable('media_manager_type_effect');
-                $mitte = sprintf( rex_effect_abstract_focuspoint::STRING, rex_effect_abstract_focuspoint::$mitte[0], rex_effect_abstract_focuspoint::$mitte[1] );
+                $mitte = sprintf(rex_effect_abstract_focuspoint::STRING, rex_effect_abstract_focuspoint::$mitte[0], rex_effect_abstract_focuspoint::$mitte[1]);
                 $qry = "SELECT id,parameters FROM $tab";
                 /** @var array<integer,string> */
-                $liste = $sql->getArray( $qry, [], PDO::FETCH_KEY_PAIR );
-                foreach( $liste as $k=>$v )
-                {
-                    $v = json_decode( $v, true );
-                    if( isset($v['rex_effect_focuspoint_fit'] ) )
-                    {
-                        if( !isset($v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_focus']) )
-                        {
+                $liste = $sql->getArray($qry, [], PDO::FETCH_KEY_PAIR);
+                foreach ($liste as $k => $v) {
+                    $v = json_decode($v, true);
+                    if (isset($v['rex_effect_focuspoint_fit'])) {
+                        if (!isset($v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_focus'])) {
                             $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_focus'] = sprintf(
                                 rex_effect_abstract_focuspoint::STRING,
-                                fpUpdateNumParaOk( $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_hpos'], 0, 50, 100 ),
-                                fpUpdateNumParaOk( $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_vpos'], 0, 50, 100 )
+                                fpUpdateNumParaOk($v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_hpos'], 0, 50, 100),
+                                fpUpdateNumParaOk($v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_vpos'], 0, 50, 100),
                             );
-                            unset( $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_hpos'] );
-                            unset( $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_vpos'] );
+                            unset($v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_hpos']);
+                            unset($v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_vpos']);
                         }
-                        if( !isset($v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_meta']) )
-                        {
+                        if (!isset($v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_meta'])) {
                             $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_meta'] =
                                 $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_fp'] == rex_i18n::msg('media_manager_effekt_focuspointfit_fp_inherit')
-                                ? 'default ('.rex_i18n::msg('focuspoint_edit_label_focus').')'
+                                ? 'default (' . rex_i18n::msg('focuspoint_edit_label_focus') . ')'
                                 : rex_effect_abstract_focuspoint::MED_DEFAULT;
-                            unset( $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_fp'] );
+                            unset($v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_fp']);
                         }
-                        if( isset($v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom']) &&
-                            preg_match( '(0%|25%|50%|75%|100%)', $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom'], $match )  &&
-                            count($match) > 0 )
-                        {
+                        if (isset($v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom']) &&
+                            preg_match('(0%|25%|50%|75%|100%)', $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom'], $match) &&
+                            count($match) > 0) {
                             $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom'] = $match[0];
                         } else {
                             $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom'] = '0%';
                         }
                     }
-                    if( isset($v['rex_effect_focuspoint_resize'] ) )
-                    {
-                        if( !isset($v['rex_effect_focuspoint_resize']['rex_effect_focuspoint_resize_focus']) )
-                        {
+                    if (isset($v['rex_effect_focuspoint_resize'])) {
+                        if (!isset($v['rex_effect_focuspoint_resize']['rex_effect_focuspoint_resize_focus'])) {
                             $v['rex_effect_focuspoint_resize']['rex_effect_focuspoint_resize_focus'] = $mitte;
                         }
-                        if( !isset($v['rex_effect_focuspoint_resize']['rex_effect_focuspoint_resize_meta']) )
-                        {
+                        if (!isset($v['rex_effect_focuspoint_resize']['rex_effect_focuspoint_resize_meta'])) {
                             $v['rex_effect_focuspoint_resize']['rex_effect_focuspoint_resize_meta'] = rex_effect_abstract_focuspoint::MED_DEFAULT;
                         }
                     }
-                    $sql->setTable( $tab );
-                    $sql->setValue( 'parameters', json_encode( $v ) );
-                    $sql->setWhere( 'id=:id', [':id'=>$k] );
+                    $sql->setTable($tab);
+                    $sql->setValue('parameters', json_encode($v));
+                    $sql->setWhere('id=:id', [':id' => $k]);
                     $sql->update();
                 }
 
                 // add media-manager-type for interactiv focuspoint-selection
                 // don't check existance of effect "resize"; just setup.
-                $sql->setQuery('select id, name from '.rex::getTable('media_manager_type').' where name="'.rex_effect_abstract_focuspoint::MM_TYPE.'" LIMIT 1');
-                if( $sql->getRows() ) {
+                $sql->setQuery('select id, name from ' . rex::getTable('media_manager_type') . ' where name="' . rex_effect_abstract_focuspoint::MM_TYPE . '" LIMIT 1');
+                if ($sql->getRows()) {
                     $id = $sql->getValue('id');
                 } else {
-                    $sql->setTable( rex::getTable('media_manager_type') );
-                    $sql->setValue( 'name', rex_effect_abstract_focuspoint::MM_TYPE );
+                    $sql->setTable(rex::getTable('media_manager_type'));
+                    $sql->setValue('name', rex_effect_abstract_focuspoint::MM_TYPE);
                     $sql->insert();
                     $id = $sql->getLastId();
                 }
-                $sql->setTable( rex::getTable('media_manager_type_effect') );
-                $sql->setWhere( 'type_id='.$id );
+                $sql->setTable(rex::getTable('media_manager_type_effect'));
+                $sql->setWhere('type_id=' . $id);
                 $sql->delete();
-                $sql->setTable( rex::getTable('media_manager_type_effect') );
-                $sql->setValue( 'type_id', $id );
-                $sql->setValue( 'effect', 'resize' );
-                $sql->setValue( 'parameters', '{"rex_effect_resize":{"rex_effect_resize_width":"1024","rex_effect_resize_height":"1024","rex_effect_resize_style":"maximum","rex_effect_resize_allow_enlarge":"enlarge"}}' );
+                $sql->setTable(rex::getTable('media_manager_type_effect'));
+                $sql->setValue('type_id', $id);
+                $sql->setValue('effect', 'resize');
+                $sql->setValue('parameters', '{"rex_effect_resize":{"rex_effect_resize_width":"1024","rex_effect_resize_height":"1024","rex_effect_resize_style":"maximum","rex_effect_resize_allow_enlarge":"enlarge"}}');
                 $sql->addGlobalUpdateFields();
                 $sql->addGlobalCreateFields();
                 $sql->insert();
 
             } catch (Exception $e) {
-                $message = rex_i18n::msg( 'focuspoint_update_error' ) . ' ' . $e->getMessage();
+                $message = rex_i18n::msg('focuspoint_update_error') . ' ' . $e->getMessage();
             }
         }
     }
     // no valid type_id
-    else
-    {
-        $message = rex_i18n::msg( 'focuspoint_install_type_error', rex_effect_abstract_focuspoint::META_FIELD_TYPE, "<strong><i>$type_id</i></strong>" );
+    else {
+        $message = rex_i18n::msg('focuspoint_install_type_error', rex_effect_abstract_focuspoint::META_FIELD_TYPE, "<strong><i>$type_id</i></strong>");
     }
 
-    if( $message )
-    {
+    if ($message) {
         $sql->rollBack();
-        $this->setProperty('updatemsg', $message );
-    }
-    else
-    {
+        $this->setProperty('updatemsg', $message);
+    } else {
         $sql->commit();
     }
 
 }
 
-
 /**
- *  @param string|integer|float $para
+ *  @param string|int|float $para
  *  @param int|float $low
  *  @param int|float $default
  *  @param int|float $high
  *  @return int|float
  */
 
-function fpUpdateNumParaOk( $para, $low=0, $default=0, $high=0 )
+function fpUpdateNumParaOk($para, $low = 0, $default = 0, $high = 0)
 {
-    $para = trim( $para );
-    return ( empty($para) || !is_numeric($para) || $para < $low || $para > $high ) ? $default : (int)$para;
+    $para = trim($para);
+    return (empty($para) || !is_numeric($para) || $para < $low || $para > $high) ? $default : (int) $para;
 }

--- a/update.php
+++ b/update.php
@@ -18,7 +18,7 @@
  *  @var rex_addon $this
  */
 
-namespace FriendsOfREDAXO\focuspoint;
+namespace FriendsOfRedaxo\focuspoint;
 
 use Exception;
 


### PR DESCRIPTION
Alle dafür geeigneten Dateien sind nun im Namespace `FriendsOfRedaxo\focuspoint`. Ausgenommen die Klassen `rex_api_focuspoint`, `rex_effect_focuspoint_abstract` und `rex_effect_focuspoint_fit`, bei denen das von REDAXO benutze Namensschema keinen Namespace zulässt.

Für eine Übergangszeit bis zu Version 5.0, die nach Einführung von REDAXO 6 (Composer-basierte Installation) erscheinen soll, stehen Weiterhin die alten Klassennamen zur Verfügung. Sie sind als `deprecated` markiert und werden in der IDE entsprechend sichtbar.