### PR TITLE
Zusatzliche Massnahmen zur Namespace-Umstellung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## **xx.02.2024 Version 4.2.0**
+
+- Umstellung der Klassennamen im Namespace auf CamelCase unter Wegfall von _.
+  Beispiel `focuspoint_media` -> `FocuspointMedia`
+- Anpassen der Dateinamen an die Klassennamen
+
+Ausnahme: auf `rex_effect` und `rex_api` aufsetzende Klassen
+
+Bugfix: 
+- StrToLower per array-Walk in die vorhergehende SQL-Abfrage verlagert. 
+
 ## **01.02.2024 Version 4.1.0**
 
 - Umstellung auf den Namespace **FriendsOfRedaxo\Focuspoint**. Aus Klasse `xyz` wird `FriendsOfRedaxo\Focuspoint\xyz`. 

--- a/boot.php
+++ b/boot.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.1.0
+ *  @version     4.2.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -29,32 +29,32 @@ if (rex::isBackend()) {
     switch (rex_request('page', 'string')) {
         case 'mediapool/media':
             // provide support for media detail-page
-            focuspoint_boot::mediaDetailPage($this);
+            FocuspointBoot::mediaDetailPage($this);
             break;
 
         case 'metainfo/articles':
         case 'metainfo/categories':
         case 'metainfo/clangs':
             // delete focuspoint-datatype from html-select for articles/categories/clangs
-            focuspoint_boot::metainfoDefault();
+            FocuspointBoot::metainfoDefault();
             break;
 
         case 'metainfo/media':
             // prevent deletion of meta-fields still in use by effects
             // limit changing the default-focuspoint-metafield: fieldname, fieldtype, no delete
             // don´t remove the default-Metafield
-            focuspoint_boot::metainfoMedia();
+            FocuspointBoot::metainfoMedia();
             break;
 
         case 'media_manager/types':
             // prevent deletion and editing of mediamanager-type used by focuspoint
-            focuspoint_boot::media_managerTypes();
+            FocuspointBoot::media_managerTypes();
             break;
 
         case 'packages':
             // prevent deactivation if in use by effects
             // effective only in dialog-mode via AddOn-administration-page
-            focuspoint_boot::packages($this);
+            FocuspointBoot::packages($this);
             break;
     }
 

--- a/docs/changes_2_0.md
+++ b/docs/changes_2_0.md
@@ -8,7 +8,7 @@ Version 2.0 ist komplett neu entwickelt. Am Grundprinzip hat sich nichts geände
 Allerdings sind einige Erweiterungen hinzugekommen, die die Nutzung erweitern und erleichtern, sowie
 strukturelle Änderungen.
 
-- die Klasse `focuspoint_media` erweitert `rex_media` mit einer zusätzlichen Methode zum Abruf valider Koordinaten
+- die Klasse `FocuspointMedia` erweitert `rex_media` mit einer zusätzlichen Methode zum Abruf valider Koordinaten
 - Die Klasse `rex_effect_abstract_focuspoint` erweitert "rex_effect_abstract" um Fokuspunkt-bezogene Methoden und dient als Basis der mitgelieferten und für eigene Media-Manager-Effekte
 - Zusätzliche eigene Fokuspunkt-Felder mit dem neuen Metatyp `Focuspoint (AddOn)`
 - Verbesserte interaktive Fokuspunkt-Zuordnung im Media-Detailformular
@@ -36,9 +36,9 @@ Um einen dem alten Feld vergleichbaren Wert zu erhalten, sollte die Koordinate i
 Einzelwerten abgerufen werden. Man kann die Einzelwerte nach Bedarf weiterverarbeiten.
 
 ```
-use FriendsOfRedaxo\Focuspoint\focuspoint_media;
+use FriendsOfRedaxo\Focuspoint\FocuspointMedia;
 
-$fpMedia = focuspoint_media::get( $filename );  // statt rex_media::get( $filename )
+$fpMedia = FocuspointMedia::get( $filename );  // statt rex_media::get( $filename )
 list( $x, $y) = $fpMedia->getFocus();           // Abruf von "med_focuspoint" als [$x,$y]
 $fp = "$x%,$y%";                                // Verwendung
 ```
@@ -52,30 +52,10 @@ Wert zwischen -1 (links bzw. unten) und 1 (rechts bzw. oben).
 - neu: 50.0,60.0
 
 ```
-use FriendsOfRedaxo\Focuspoint\focuspoint_media;
+use FriendsOfRedaxo\Focuspoint\FocuspointMedia;
 
-$fpMedia = focuspoint_media::get( $filename );  // statt rex_media::get( $filename )
+$fpMedia = FocuspointMedia::get( $filename );  // statt rex_media::get( $filename )
 list( $x_neu, $y_neu) = $fpMedia->getFocus();    // Abruf von "med_focuspoint" als [$x,$y]
 $x_alt = $x_neu / 50 - 1;                       // X-Koordinate umrechnen
 $y_alt = 1 - $y_neu / 50;                       // Y-Koordinate umrechnen
 ```
-
-## Media-Manager-Effekt "focuspoint_resize"
-
-Der Effekt `focuspoint_resize` für den Media-Manager wird nicht mehr unterstützt, da sich in Umfragen keine
-Nutzer gemeldet haben. Der Effekt ist noch im Addon enthalten und wird erst in Version 2.2 vollständig entfernt werden.
-Die Dokumentation geht nicht weiter auf den Effekt ein.
-
-**Empfehlung:**
-Ersatz durch den Effekt `focuspoint_fit`. Die Parametrisierung ist allerdings so unterschiedlich, dass
-keine konkrete Empfehlung gegeben werden kann, wie das Resize-Ergebnis exakt reproduziert werden kann.
-Der Grund: "resize" orientiert sich am Ausgangsbild, "fit" am Zielformat.
-
-Wer auf keinen Fall auf den Effekt verzichten kann, sollte ihn perspektivisch in das Projekt-Addon
-verschieben.
-
-**Roadmap:**
-
-- Version 2.0: Der Effekt ist als "künftig wegfallend" markiert, steht aber weiterhin (ohne Dokumentation) zur Verfügung.
-- Version 2.1: Der Effekt wird zwar weiterhin ausgeliefert, aber nicht in der boot.php aktiviert.
-- Version 2.2: Der Effekt wird komplett entfernt.

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -13,7 +13,7 @@
 > Dies sind die wichtigsten Hilfsmittel:
 >
 > - [Extension-Point `FOCUSPOINT_PREVIEW_SELECT`](#api-ep)
-> - [Klasse `focuspoint_media`](#api-rfm)
+> - [Klasse `FocuspointMedia`](#api-rfm)
 > - [Klasse `rex_effect_abstract_focuspoint`](#api-refa)
 > - [rex_api_call `focuspoint`](#api-racf)
 > - [Eigene Fokuspunkt-Effekte entwickeln](#api-mofe)
@@ -23,13 +23,13 @@ können entweder über einen vollständigen Qualifier aufgerufen werden oder dur
 
 ```
 ...
-$image = FriendsOfRedaxo\Focuspoint\focuspoint_media::get($filename);
+$image = FriendsOfRedaxo\Focuspoint\FocuspointMedia::get($filename);
 ```
 
 ```
-use FriendsOfRedaxo\Focuspoint\focuspoint_media;
+use FriendsOfRedaxo\Focuspoint\FocuspointMedia;
 ...
-$image = focuspoint_media::get($filename);
+$image = FocuspointMedia::get($filename);
 ```
 
 
@@ -99,9 +99,9 @@ rex_extension::register('FOCUSPOINT_PREVIEW_SELECT', function($ep){
 
 
 <a name="api-rfm"></a>
-## Klasse `focuspoint_media`
+## Klasse `FocuspointMedia`
 
-Die neue Klasse `focuspoint_media` erleichtert die Nutzung von Medien mit Fokuspunkt-Datenfeldern.
+Die neue Klasse `FocuspointMedia` erleichtert die Nutzung von Medien mit Fokuspunkt-Datenfeldern.
 
 Konkret stellt die Klasse zwei zusätzliche Methoden bereit:
 
@@ -123,13 +123,13 @@ eines Addons wird der Extension-Point `MEDIA_LIST_FUNCTIONS` belegt.
 Abgefragt wird das Default-Feld "med_focuspoint":
 
 ```php
-use FriendsOfRedaxo\Focuspoint\focuspoint_media;
+use FriendsOfRedaxo\Focuspoint\FocuspointMedia;
 
 if( rex_request('page', 'string') == 'mediapool/media' && !rex_request('file_id', 'string') )
 {
     rex_extension::register( 'MEDIA_LIST_FUNCTIONS', function( rex_extension_point $ep )
     {
-        $image = focuspoint_media::get( $ep->getParams()['file_name'] );
+        $image = FocuspointMedia::get( $ep->getParams()['file_name'] );
         if( $image && $image->hasValue() )
         {
             list( $x, $y) = $image->getFocus();
@@ -143,17 +143,18 @@ Falls zusätzlich individuelle Fokuspunkt-Metafelder definiert sind, kann mit di
 komplette Satz überprüft werden:
 
 ```php
-use FriendsOfRedaxo\Focuspoint\focuspoint_media;
+use FriendsOfRedaxo\Focuspoint\Focuspoint;
+use FriendsOfRedaxo\Focuspoint\FocuspointMedia;
 
 if( rex_request('page', 'string') == 'mediapool/media' && !rex_request('file_id', 'string') )
 {
     rex_extension::register( 'MEDIA_LIST_FUNCTIONS', function( rex_extension_point $ep )
     {
-        $image = focuspoint_media::get( $ep->getParams()['file_name'] );
+        $image = FocuspointMedia::get( $ep->getParams()['file_name'] );
         if( $image )
         {
             $content = [];
-            foreach( focuspoint::getMetafieldList() as $fpFeld )
+            foreach( Focuspoint::getMetafieldList() as $fpFeld )
             {
                 if( $image->hasFocus(fpFeld) )
                 {
@@ -182,12 +183,12 @@ Die Parameter sind:
 Falls das angegebene Fokuspunkt-Metafeld nicht existiert, wird nicht auf das Default-Feld
 zurückgegriffen, sondern der Fallback-Wert herangezogen.
 
-Die Klasse `focuspoint_media` kann z.B. in eigenen Effekten, die auf Fokuspunkten basieren,
+Die Klasse `FocuspointMedia` kann z.B. in eigenen Effekten, die auf Fokuspunkten basieren,
 eingesetzt werden, aber auch in beliebigen anderen Zusammenhängen. Hier ein Beispiel :
 ```php
-use FriendsOfRedaxo\Focuspoint\focuspoint_media;
+use FriendsOfRedaxo\Focuspoint\FocuspointMedia;
 
-$fpMedia = focuspoint_media::get( $filename );
+$fpMedia = FocuspointMedia::get( $filename );
 
 if ( $fpMedia )
 {
@@ -204,7 +205,7 @@ gesetzt. `true` bewirkt, dass der Rückgabewert in absolute Bildpunkte umgerechn
 Ein Bild mit den Abmessungen `1291px / 855px` ergibt auf Basis des Fallback-Wertes die Rückgabe
 `[646,513]`.
 
-> `focuspoint_media::get( $filename )` liefert nur dann ein Objekt zurück, wenn die angegebene
+> `FocuspointMedia::get( $filename )` liefert nur dann ein Objekt zurück, wenn die angegebene
 > Datei ein Bild ist, sonst `null`.
 
 
@@ -325,7 +326,7 @@ $x = $this->getMetaField(  );                     // Ergebnis: 'med_focuspoint'
 ### getFocus()
 
 ```php
-array function getFocus( focuspoint_media $media=null, array $default=null, array $wh=null )
+array function getFocus( FocuspointMedia $media=null, array $default=null, array $wh=null )
 ```
 
 Die Funktion ermittelt den für das Bild relevanten Fokuspunkt. Dabei werden unterschiedliche Quellen in folgender Reihenfolge herangezogen:
@@ -334,14 +335,14 @@ Die Funktion ermittelt den für das Bild relevanten Fokuspunkt. Dabei werden unt
 	greift Variante 2.
 2. Falls in der URL der Parameter xy=«metafeld» enthalten ist, wird statt des in der Effekt-Konfiguration ausgewählten
 	Focuspoint-Metafeldes das hier angegebene Feld benutzt. Für $media gelten die Regeln aus Punkt 3.
-3. Wenn $media ein Objekt vom Typ focuspoint_media (oder davon abgeleitet) ist, wird darüber der Fokuspunkt  
+3. Wenn $media ein Objekt vom Typ FocuspointMedia (oder davon abgeleitet) ist, wird darüber der Fokuspunkt  
 	direkt aus den Bilddaten im Medienpool abgerufen. Basis ist das in der Effekt-Konfiguration ausgewählte Metafeld.
 4. Wenn die obigen Varianten auf einen Fehler laufen bzw. keine Daten finden, wird `$default` zurückgegeben.
 5. Wenn `$default` nicht angegeben ist, wird `[50,50]` zurückgegeben (also Bildmitte).
 
 
 ```php
-$focuspoint = $this->getFocus( focuspoint_media::get( $this->media->getMediaFilename() ), [ 50,60 ] );
+$focuspoint = $this->getFocus( FocuspointMedia::get( $this->media->getMediaFilename() ), [ 50,60 ] );
 ...
 ```
 
@@ -430,7 +431,7 @@ class rex_effect_focuspoint_myeffect extends rex_effect_abstract_focuspoint
     function execute()
     {
 
-		$focuspoint = $this->getFocus( focuspoint_media::get( $this->media->getMediaFilename() ) );
+		$focuspoint = $this->getFocus( FocuspointMedia::get( $this->media->getMediaFilename() ) );
 
 		$this->media->asImage();
 		$gdimage = $this->media->getImage();

--- a/lib/FocuspointBoot.php
+++ b/lib/FocuspointBoot.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.1.0
+ *  @version     4.2.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -33,7 +33,7 @@ use function array_key_exists;
 use function count;
 
 /** @api */
-class Focuspoint_boot
+class FocuspointBoot
 {
     /**
      *  page=mediapool/media.
@@ -47,8 +47,8 @@ class Focuspoint_boot
     {
         rex_view::addCssFile($fpAddon->getAssetsUrl('focuspoint.min.css'));
         rex_view::addJsFile($fpAddon->getAssetsUrl('focuspoint.min.js'));
-        rex_extension::register('MEDIA_DETAIL_SIDEBAR', 'focuspoint::show_sidebar');
-        rex_extension::register('METAINFO_CUSTOM_FIELD', 'focuspoint::customfield');
+        rex_extension::register('MEDIA_DETAIL_SIDEBAR', [Focuspoint::class, 'show_sidebar']);
+        rex_extension::register('METAINFO_CUSTOM_FIELD', [Focuspoint::class, 'customfield']);
     }
 
     /**
@@ -66,13 +66,13 @@ class Focuspoint_boot
             rex_extension::register('REX_FORM_GET', static function (rex_extension_point $ep) {
                 try {
                     // provide access to the form-elements
-                    $formReflection = new focuspoint_reflection($ep->getSubject());
+                    $formReflection = new FocuspointReflection($ep->getSubject());
                     $fieldset = $formReflection->getPropertyValue('fieldset');
                     // search the type-select
                     $typeid = $formReflection->executeMethod('getElement', [$fieldset, 'type_id']);
-                    $typeidReflection = new focuspoint_reflection($typeid);
+                    $typeidReflection = new FocuspointReflection($typeid);
                     // get access to the internal REX_SELECT-element
-                    $selectReflection = new focuspoint_reflection($typeidReflection->getPropertyValue('select'));
+                    $selectReflection = new FocuspointReflection($typeidReflection->getPropertyValue('select'));
                     $options = $selectReflection->getPropertyValue('options');
                     foreach ($options[0][0] as $i => $o) {
                         if (rex_effect_abstract_focuspoint::META_FIELD_TYPE !== $o[0]) {
@@ -110,7 +110,7 @@ class Focuspoint_boot
         // prevent deletion of meta-fields still in use by effects
         if ('delete' === rex_request('func', 'string')) {
             rex_extension::register('PACKAGES_INCLUDED', static function (rex_extension_point $ep) {
-                $inUseMessage = focuspoint::metafield_is_in_use(rex_request('field_id', 'int', 0));
+                $inUseMessage = Focuspoint::metafield_is_in_use(rex_request('field_id', 'int', 0));
                 if ('' < $inUseMessage) {
                     // STAN: Using $_REQUEST is forbidden, use rex_request::request() or rex_request() instead.
                     // Da hat er recht, aber ich wüsste nicht, wie man es anders löst.
@@ -127,7 +127,7 @@ class Focuspoint_boot
         if ('edit' === rex_request('func', 'string')) {
             rex_extension::register('REX_FORM_GET', static function (rex_extension_point $ep) {
                 $form = $ep->getSubject();
-                $fpMetafields = focuspoint::getMetafieldList();
+                $fpMetafields = Focuspoint::getMetafieldList();
                 $field_id = rex_request('field_id', 'int');
                 if (array_key_exists($field_id, $fpMetafields)) {
                     $fpField = $fpMetafields[$field_id];
@@ -135,7 +135,7 @@ class Focuspoint_boot
 
                     try {
                         // provide access to the form-elements
-                        $formReflection = new focuspoint_reflection($ep->getSubject());
+                        $formReflection = new FocuspointReflection($ep->getSubject());
                         $fieldset = $formReflection->getPropertyValue('fieldset');
                         $elements = $formReflection->getPropertyValue('elements');
                         $fselements = $elements[$fieldset] ?? [];
@@ -145,10 +145,10 @@ class Focuspoint_boot
                             $message .= rex_i18n::msg('focuspoint_edit_msg_inuse2', $fpField) . '<br>';
                         }
                         // focuspoint-fields in use will get restrictions
-                        $effects = focuspoint::getFocuspointMetafieldInUse($fpField);
+                        $effects = Focuspoint::getFocuspointMetafieldInUse($fpField);
                         if (0 < count($effects)) {
                             $message .= rex_i18n::msg('focuspoint_edit_msg_inuse1', $fpField) .
-                               '<br>' . focuspoint::getFocuspointEffectsInUseMessage($effects);
+                               '<br>' . Focuspoint::getFocuspointEffectsInUseMessage($effects);
                         }
                         if ('' < $message) {
                             $message .= rex_i18n::msg('focuspoint_edit_msg_inuse3', rex_i18n::msg('minfo_field_label_name'), rex_i18n::msg('minfo_field_label_type'));
@@ -174,7 +174,7 @@ class Focuspoint_boot
                                 if ('rex_form_control_element' === $e::class) {
                                     // don´t delete the default-field or fields in use
                                     // so remove the delete-button
-                                    $controlReflection = new focuspoint_reflection($e);
+                                    $controlReflection = new FocuspointReflection($e);
                                     $controlReflection->setPropertyValue('deleteElement', null);
                                     continue;
                                 }
@@ -193,7 +193,7 @@ class Focuspoint_boot
             $list = $ep->getSubject();
             // Erkenntnis aus rexstan: $effectsInUse wird in der custom-function nicht (mehr) benutzt.
             // Erst mal als Kommentar im Code belassen
-            //            $effectsInUse = focuspoint::getFocuspointEffectsInUse();
+            //            $effectsInUse = Focuspoint::getFocuspointEffectsInUse();
             //            $list->setColumnFormat('delete', 'custom', function ($params) use($effectsInUse) {
             $list->setColumnFormat('delete', 'custom', static function ($params) {
                 $list = $params['list'];
@@ -202,7 +202,7 @@ class Focuspoint_boot
                 }
                 // planned with V3.0 because it is a breaking change:
                 //   show detailed in-use-information insteag of a "blocked"
-                // if( $inUse = focuspoint::metafield_is_in_use( $list->getValue('id') ) ) return '<small class="text-muted">'.$inUse.'</small>';
+                // if( $inUse = Focuspoint::metafield_is_in_use( $list->getValue('id') ) ) return '<small class="text-muted">'.$inUse.'</small>';
                 if ($presetValue = $params['params'][0]) {
                     return $list->formatValue('', $presetValue, false, 'delete');
                 }
@@ -257,7 +257,7 @@ class Focuspoint_boot
                     rex_extension::register('REX_FORM_GET', static function (rex_extension_point $ep) {
                         $form = $ep->getSubject();
                         // provide access to the form-elements
-                        $formReflection = new focuspoint_reflection($form);
+                        $formReflection = new FocuspointReflection($form);
                         $fieldset = $formReflection->getPropertyValue('fieldset');
                         $elements = $formReflection->getPropertyValue('elements');
                         $fselements = $elements[$fieldset] ?? [];

--- a/lib/FocuspointMedia.php
+++ b/lib/FocuspointMedia.php
@@ -12,7 +12,7 @@
  *
  *  ------------------------------------------------------------------------------------------------
  *
- *  Die Klasse "focuspoint_media" ist von "rex_media" abgeleitet und erleichetrt den
+ *  Die Klasse "FocuspointMedia" ist von "rex_media" abgeleitet und erleichetrt den
  *  Umgang mit Medien, deren Darstellung auf Fokuspunkten basiert.
  */
 
@@ -22,7 +22,7 @@ use rex_effect_abstract_focuspoint;
 use rex_media;
 
 /** @api */
-class Focuspoint_media extends rex_media
+class FocuspointMedia extends rex_media
 {
     /**
      *  Gibt die Bildinstanz zurück und prüft dabei ab, ob es ein Bild ist (isImage).

--- a/lib/FocuspointReflection.php
+++ b/lib/FocuspointReflection.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.1.0
+ *  @version     4.2.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -11,7 +11,7 @@
  *
  *  ------------------------------------------------------------------------------------------------
  *
- *  focuspoint_reflection ist eine erweiterte PHP ReflectionClass. Sie erlaubt auf etwas
+ *  FocuspointReflection ist eine erweiterte PHP ReflectionClass. Sie erlaubt auf etwas
  *  vereinfachte Art Properties abzufragen oder zu ändern bzw. Methoden auszuführen, die
  *  in der Klasse ansonsten nicht zugänglich sind (private oder protected)
  *
@@ -22,7 +22,7 @@ namespace FriendsOfRedaxo\Focuspoint;
 
 use ReflectionClass;
 
-class Focuspoint_reflection extends ReflectionClass
+class FocuspointReflection extends ReflectionClass
 {
     /**
      * @var object

--- a/lib/effect_abstract_focuspoint.php
+++ b/lib/effect_abstract_focuspoint.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.1.0
+ *  @version     4.2.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -20,7 +20,7 @@
  *  "rex_effect_abstract"!
  */
 
-use FriendsOfRedaxo\Focuspoint\Focuspoint_media;
+use FriendsOfRedaxo\Focuspoint\FocuspointMedia;
 
 /** @api */
 abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
@@ -69,7 +69,7 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
      *  @param  array<mixed>    $xy     Array [x,y] der relativen Koordinaten (0..100)
      *  @param  array<mixed>    $wh     Array [breite,höhe] der Bildabmessungen
      *
-     *  @return array<integer>            [x,y] als absolute Werte der Fokuspunkt-Koordinate
+     *  @return array<int>            [x,y] als absolute Werte der Fokuspunkt-Koordinate
      */
     public static function rel2px(array $xy, array $wh)
     {
@@ -124,7 +124,7 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
      *  Falls $media kein gültiges Objekt aus dem Medienpool ist (z.B. wenn der Medienpfad mit dem
      *  vorgeschalteten Effekt "mediapath" geändert wurde), werden die Defaultwerte herangezogen.
      *
-     *  @param  focuspoint_media    $media    Media-Objekt oder null
+     *  @param  FocuspointMedia     $media    Media-Objekt oder null
      *  @param  array<mixed>        $default  Default-Koordinaten falls auf anderem Wege keine
      *                                        gültigen Koordinaten ermittelt werden können
      *  @param  array<mixed>        $wh       array [breite,höhe] mit den Referenzwerten, auf die
@@ -140,13 +140,14 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
             // hier eingebaut zur Funktionsfähigkeit von focuspoint_api
             $fp = self::str2fp($xy);
             if (false === $fp) {
-                $fp = null !== $media && is_a($media, 'focuspoint_media')
+                // TODO: oder FocuspointMedia::class ?
+                $fp = null !== $media && is_a($media, 'FocuspointMedia')
                     ? $media->getFocus($xy, $default) // $xy = Meta-Feld-Name??
                     : $this->getDefaultFocus($default);
             }
         } else {
             // Standard
-            $fp = null !== $media && is_a($media, 'focuspoint_media')
+            $fp = null !== $media && is_a($media, 'FocuspointMedia')
                 ? $media->getFocus($this->getMetaField(), $default)
                 : $this->getDefaultFocus($default);
         }
@@ -170,10 +171,9 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
      */
     public function getParams()
     {
-        $qry = 'SELECT id,name FROM ' . rex::getTable('metainfo_field') . ' WHERE type_id=(SELECT id FROM ' . rex::getTable('metainfo_type') . ' WHERE label="' . self::META_FIELD_TYPE . '"  LIMIT 1) AND name LIKE "med_%" ORDER BY name ASC';
+        $qry = 'SELECT id,LOWER(name) as name FROM ' . rex::getTable('metainfo_field') . ' WHERE type_id=(SELECT id FROM ' . rex::getTable('metainfo_type') . ' WHERE label="' . self::META_FIELD_TYPE . '"  LIMIT 1) AND name LIKE "med_%" ORDER BY name ASC';
         $felder = rex_sql::factory()->getArray($qry, [], PDO::FETCH_KEY_PAIR);
         $felder[] = 'default => ' . rex_i18n::msg('focuspoint_edit_label_focus');
-        array_walk($felder, 'strtolower');
         $default = current($felder);
         if (($k = array_search(self::MED_DEFAULT, $felder, true)) !== false) {
             $default = $felder[$k];

--- a/lib/effect_abstract_focuspoint.php
+++ b/lib/effect_abstract_focuspoint.php
@@ -140,14 +140,13 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
             // hier eingebaut zur Funktionsfähigkeit von focuspoint_api
             $fp = self::str2fp($xy);
             if (false === $fp) {
-                // TODO: oder FocuspointMedia::class ?
-                $fp = null !== $media && is_a($media, 'FocuspointMedia')
+                $fp = null !== $media && is_a($media, FocuspointMedia::class)
                     ? $media->getFocus($xy, $default) // $xy = Meta-Feld-Name??
                     : $this->getDefaultFocus($default);
             }
         } else {
             // Standard
-            $fp = null !== $media && is_a($media, 'FocuspointMedia')
+            $fp = null !== $media && is_a($media, FocuspointMedia::class)
                 ? $media->getFocus($this->getMetaField(), $default)
                 : $this->getDefaultFocus($default);
         }

--- a/lib/effect_focuspoint_fit.php
+++ b/lib/effect_focuspoint_fit.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.1.0
+ *  @version     4.2.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -45,7 +45,7 @@
  *  Beispiel: $dw, $dh, $dr
  */
 
-use FriendsOfRedaxo\Focuspoint\Focuspoint_media;
+use FriendsOfRedaxo\Focuspoint\FocuspointMedia;
 
 /** @api */
 class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
@@ -88,7 +88,7 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
                 dann den FP des Bildes.
                 Umrechnen in absolute Bildkoordinaten (Pixel)
         */
-        [$fx, $fy] = $this->getFocus(focuspoint_media::get($this->media->getMediaFilename()), $this->getDefaultFocus(), [$sw, $sh]);
+        [$fx, $fy] = $this->getFocus(FocuspointMedia::get($this->media->getMediaFilename()), $this->getDefaultFocus(), [$sw, $sh]);
 
         /*--------------------------
 

--- a/lib/focuspoint.php
+++ b/lib/focuspoint.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.1.0
+ *  @version     4.2.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -90,7 +90,7 @@ class Focuspoint
         if (false === $p2) {
             return;
         }
-        $p2 = $p2 + 4;
+        $p2 += 4;
 
         $fragment = new rex_fragment();
         $fragment->setVar('mediafile', $mediafile);
@@ -421,7 +421,6 @@ class Focuspoint
     {
         $message = '';
         foreach ($effekte as $effect) {
-            /** @ var rex_effect_abstract $target */
             /** @var non-falsy-string $target */
             $target = "rex_effect_{$effect['effect']}";
             $name = new $target();

--- a/lib/focuspoint_api.php
+++ b/lib/focuspoint_api.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.1.0
+ *  @version     4.2.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -49,7 +49,7 @@ class rex_api_focuspoint extends rex_api_function
         $mediatype = rex_request('type', 'string', '');
 
         if ('' < $mediafile && '' < $mediatype) {
-            $bild = focuspoint_media_manager::createMedia($mediatype, $mediafile);
+            $bild = FocuspointMediaManager::createMedia($mediatype, $mediafile);
             $bild->sendMedia('', '');
         }
         exit;
@@ -60,7 +60,7 @@ class rex_api_focuspoint extends rex_api_function
  *  Da die wichtige Funktion rex_media_manager->applyEffects 'protected' ist, muss eine abgeleitete
  *  Klasse "focuspoint_media_manager" zwischengeschaltet werden, um das neue Bild zu generieren.
  */
-class focuspoint_media_manager extends rex_media_manager
+class FocuspointMediaManager extends rex_media_manager
 {
     /**
      *  Erzeugt das Bild des media-Effektes.

--- a/lib/no_namespace/focuspoint.php
+++ b/lib/no_namespace/focuspoint.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.1.0
+ *  @version     4.2.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -20,6 +20,4 @@
  * @see https://github.com/orgs/FriendsOfREDAXO/discussions/40
  */
 
-class focuspoint extends FriendsOfRedaxo\Focuspoint\Focuspoint
-{
-}
+class xfocuspoint extends FriendsOfRedaxo\Focuspoint\Focuspoint {}

--- a/lib/no_namespace/focuspoint.php
+++ b/lib/no_namespace/focuspoint.php
@@ -16,8 +16,8 @@
  * auf diesem Wege weiterhin bereitgestellt. Diese Klasse fällt mit Version 5.0.0 weg, nachdem
  * Redaxo auf Composer als Installer umgestellt wurde.
  *
- * @deprecated 5.0.0 Aufrufe auf "FriendsOfRedaxo\Focuspoint\focuspoint" (Namespace) umstellen
+ * @deprecated 5.0.0 Aufrufe auf "FriendsOfRedaxo\Focuspoint\Focuspoint" (Namespace) umstellen
  * @see https://github.com/orgs/FriendsOfREDAXO/discussions/40
  */
 
-class xfocuspoint extends FriendsOfRedaxo\Focuspoint\Focuspoint {}
+class focuspoint extends FriendsOfRedaxo\Focuspoint\Focuspoint {}

--- a/lib/no_namespace/focuspoint_boot.php
+++ b/lib/no_namespace/focuspoint_boot.php
@@ -20,6 +20,4 @@
  * @see https://github.com/orgs/FriendsOfREDAXO/discussions/40
  */
 
-class focuspoint_boot extends FriendsOfRedaxo\Focuspoint\Focuspoint_boot
-{
-}
+class xfocuspoint_boot extends FriendsOfRedaxo\Focuspoint\FocuspointBoot {}

--- a/lib/no_namespace/focuspoint_boot.php
+++ b/lib/no_namespace/focuspoint_boot.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.1.0
+ *  @version     4.2.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -16,8 +16,8 @@
  * auf diesem Wege weiterhin bereitgestellt. Diese Klasse fällt mit Version 5.0.0 weg, nachdem
  * Redaxo auf Composer als Installer umgestellt wurde.
  *
- * @deprecated 5.0.0 Aufrufe auf "FriendsOfRedaxo\Focuspoint\focuspoint_boot" (Namespace) umstellen
+ * @deprecated 5.0.0 Aufrufe auf "FriendsOfRedaxo\Focuspoint\FocuspointBoot" (Namespace) umstellen
  * @see https://github.com/orgs/FriendsOfREDAXO/discussions/40
  */
 
-class xfocuspoint_boot extends FriendsOfRedaxo\Focuspoint\FocuspointBoot {}
+class focuspoint_boot extends FriendsOfRedaxo\Focuspoint\FocuspointBoot {}

--- a/lib/no_namespace/focuspoint_media.php
+++ b/lib/no_namespace/focuspoint_media.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.1.0
+ *  @version     4.2.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -16,10 +16,8 @@
  * auf diesem Wege weiterhin bereitgestellt. Diese Klasse fällt mit Version 5.0.0 weg, nachdem
  * Redaxo auf Composer als Installer umgestellt wurde.
  *
- * @deprecated 5.0.0 Aufrufe auf "FriendsOfRedaxo\Focuspoint\focuspoint_media" (Namespace) umstellen
+ * @deprecated 5.0.0 Aufrufe auf "FriendsOfRedaxo\Focuspoint\FocuspointMedia" (Namespace) umstellen
  * @see https://github.com/orgs/FriendsOfREDAXO/discussions/40
  */
 
-class focuspoint_media extends FriendsOfRedaxo\Focuspoint\Focuspoint_media
-{
-}
+class xfocuspoint_media extends FriendsOfRedaxo\Focuspoint\FocuspointMedia {}

--- a/lib/no_namespace/focuspoint_media.php
+++ b/lib/no_namespace/focuspoint_media.php
@@ -20,4 +20,4 @@
  * @see https://github.com/orgs/FriendsOfREDAXO/discussions/40
  */
 
-class xfocuspoint_media extends FriendsOfRedaxo\Focuspoint\FocuspointMedia {}
+class focuspoint_media extends FriendsOfRedaxo\Focuspoint\FocuspointMedia {}

--- a/lib/no_namespace/focuspoint_reflection.php
+++ b/lib/no_namespace/focuspoint_reflection.php
@@ -20,4 +20,4 @@
  * @see https://github.com/orgs/FriendsOfREDAXO/discussions/40
  */
 
-class xfocuspoint_reflection extends FriendsOfRedaxo\Focuspoint\FocuspointReflection {}
+class focuspoint_reflection extends FriendsOfRedaxo\Focuspoint\FocuspointReflection {}

--- a/lib/no_namespace/focuspoint_reflection.php
+++ b/lib/no_namespace/focuspoint_reflection.php
@@ -4,7 +4,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.1.0
+ *  @version     4.2.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -16,10 +16,8 @@
  * auf diesem Wege weiterhin bereitgestellt. Diese Klasse fällt mit Version 5.0.0 weg, nachdem
  * Redaxo auf Composer als Installer umgestellt wurde.
  *
- * @deprecated 5.0.0 Aufrufe auf "FriendsOfRedaxo\Focuspoint\focuspoint_reflection" (Namespace) umstellen
+ * @deprecated 5.0.0 Aufrufe auf "FriendsOfRedaxo\Focuspoint\FocuspointReflection" (Namespace) umstellen
  * @see https://github.com/orgs/FriendsOfREDAXO/discussions/40
  */
 
-class focuspoint_reflection extends FriendsOfRedaxo\Focuspoint\Focuspoint_reflection
-{
-}
+class xfocuspoint_reflection extends FriendsOfRedaxo\Focuspoint\FocuspointReflection {}

--- a/precheck.php
+++ b/precheck.php
@@ -3,7 +3,7 @@
  *  This file is part of the REDAXO-AddOn "focuspoint".
  *
  *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
- *  @version     4.1.0
+ *  @version     4.2.0
  *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
  *
  *  For the full copyright and license information, please view the LICENSE
@@ -73,19 +73,19 @@ switch ($request) {
         // noop
         break;
     case 'activate':
-        $message = focuspoint::checkActivateDependencies();
+        $message = Focuspoint::checkActivateDependencies();
         $header = 'addon_no_activation';
         break;
     case 'deactivate':
-        $message = focuspoint::checkDeactivateDependencies();
+        $message = Focuspoint::checkDeactivateDependencies();
         $header = 'addon_no_deactivation';
         break;
     case 'uninstall':
-        $message = focuspoint::checkUninstallDependencies();
+        $message = Focuspoint::checkUninstallDependencies();
         $header = 'addon_no_uninstall';
         break;
     case 'delete':
-        $message = focuspoint::checkUninstallDependencies();
+        $message = Focuspoint::checkUninstallDependencies();
         $header = 'addon_not_deleted';
         break;
 }

--- a/precheck.php
+++ b/precheck.php
@@ -52,16 +52,13 @@
 namespace FriendsOfRedaxo\Focuspoint;
 
 use rex_addon;
+use rex_functional_exception;
+use rex_i18n;
 
 /**
  * @var rex_addon $this
  * @var string $request Ist aus dem aufrufenden Context vorhanden
  */
-
-namespace FriendsOfRedaxo\Focuspoint;
-
-use rex_functional_exception;
-use rex_i18n;
 
 $message = '';
 $header = '';

--- a/update.php
+++ b/update.php
@@ -126,7 +126,7 @@ if (rex_version::compare($this->getVersion(), '2.0', '<')) {
                 rex_metainfo_delete_field('med_focuspoint_data');
                 rex_metainfo_delete_field('med_focuspoint_css');
 
-                // update parameter-set per field "focuspoint-fit" and "focuspoint-resize" to new structure"
+                // update parameter-set per field "focuspoint-fit" to new structure"
 
                 $tab = rex::getTable('media_manager_type_effect');
                 $mitte = sprintf(rex_effect_abstract_focuspoint::STRING, rex_effect_abstract_focuspoint::$mitte[0], rex_effect_abstract_focuspoint::$mitte[1]);


### PR DESCRIPTION
- Bugfix zu #130: hier musste in `rex_effect_abstract_focuspoint` das `is_a($media, 'FocuspointMedia)` in ein `is_a($media, FocuspointMedia::class)` geändert werden, um den komplette Namespace mitzugeben.
- Bugfix zu #129 
- Umstellung der Klassennamen auf CamelCase 
- Anpassung der Dateinamen

nicht umgestellt: mit rex_api oder rex_effect beginnende Klassen, die eh nicht Namespace-fähig sind.