### PR TITLE
First class callable syntax

### DIFF
--- a/lib/FocuspointBoot.php
+++ b/lib/FocuspointBoot.php
@@ -47,8 +47,8 @@ class FocuspointBoot
     {
         rex_view::addCssFile($fpAddon->getAssetsUrl('focuspoint.min.css'));
         rex_view::addJsFile($fpAddon->getAssetsUrl('focuspoint.min.js'));
-        rex_extension::register('MEDIA_DETAIL_SIDEBAR', [Focuspoint::class, 'show_sidebar']);
-        rex_extension::register('METAINFO_CUSTOM_FIELD', [Focuspoint::class, 'customfield']);
+        rex_extension::register('MEDIA_DETAIL_SIDEBAR', Focuspoint::show_sidebar(...));
+        rex_extension::register('METAINFO_CUSTOM_FIELD', Focuspoint::customfield(...));
     }
 
     /**


### PR DESCRIPTION
EP-Aufrufe auf die "First class callable syntax" ab PHP 8.1 umgestellt