### PR TITLE
Verbessere UX, Uninstall-Cleanup und Rexstan-Stabilitaet

### DIFF
--- a/assets/focuspoint.css
+++ b/assets/focuspoint.css
@@ -56,5 +56,15 @@
 }
 
 .focuspoint-panel button[data-button="zoom"] .fa-search-minus { display:none; }
-.col-sm-12 .focuspoint-panel button[data-button="zoom"] .fa-search-plus { display:none; }
-.col-sm-12 .focuspoint-panel button[data-button="zoom"] .fa-search-minus { display:inline; }
+.focuspoint-panel.focuspoint-panel-zoom button[data-button="zoom"] .fa-search-plus { display:none; }
+.focuspoint-panel.focuspoint-panel-zoom button[data-button="zoom"] .fa-search-minus { display:inline; }
+
+.focuspoint-panel.focuspoint-panel-zoom {
+    position: relative;
+    z-index: 10;
+}
+
+.focuspoint-panel.focuspoint-panel-zoom > .focuspoint-panel-image > img {
+    max-height: 75vh;
+    object-fit: contain;
+}

--- a/assets/focuspoint.css
+++ b/assets/focuspoint.css
@@ -60,11 +60,25 @@
 .focuspoint-panel.focuspoint-panel-zoom button[data-button="zoom"] .fa-search-minus { display:inline; }
 
 .focuspoint-panel.focuspoint-panel-zoom {
-    position: relative;
-    z-index: 10;
+    position: fixed;
+    top: 2vh;
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(1100px, 96vw);
+    max-height: 96vh;
+    overflow: auto;
+    background: #fff;
+    box-shadow: 0 20px 70px rgba(0, 0, 0, 0.45);
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 6px;
+    z-index: 2000;
 }
 
 .focuspoint-panel.focuspoint-panel-zoom > .focuspoint-panel-image > img {
-    max-height: 75vh;
+    max-height: 68vh;
     object-fit: contain;
+}
+
+body.focuspoint-overlay-open {
+    overflow: hidden;
 }

--- a/assets/focuspoint.css
+++ b/assets/focuspoint.css
@@ -12,13 +12,17 @@
     width: 100%;
 }
 .focuspoint-panel-select > * {
-    font-size: 70%;
+    font-size: 85%;
 }
 .focuspoint-panel > .focuspoint-panel-image {
     padding: 0;
     position: relative;
     cursor: crosshair;
     cursor: url('cross.png') 48 48, crosshair;
+    outline: 0;
+}
+.focuspoint-panel > .focuspoint-panel-image:focus {
+    box-shadow: inset 0 0 0 2px rgba(51, 122, 183, 0.8);
 }
 .focuspoint-panel  > .focuspoint-panel-image > img {
     width: 100%;
@@ -36,7 +40,7 @@
     top: 50%;
     left: 50%;
     margin: -50px 49px 49px -50px;
-    transition: top,left, 300ms ease-in-out;
+    transition: top 300ms ease-in-out, left 300ms ease-in-out;
 }
 .focuspoint-panel > small {
     display: block;

--- a/assets/focuspoint.js
+++ b/assets/focuspoint.js
@@ -62,13 +62,13 @@ function fpCreateController ( container, mediafile )
                                 {
                                     if( this.domPreviewContainer.hasClass('hidden') ) return this;
                                     if( this.mediatype == '' ) { this.domPreviewOff.click(); return; }
-                                    this.domPreviewImage.attr( 'src',
-                                        location.pathname +
-                                        location.search +
-                                        '&rex-api-call=focuspoint&type=' + this.mediatype +
-                                        '&file=' + this.mediafile +
-                                        '&xy=' + this.cPos.asData()
-                                    );
+                                    var previewUrl = new URL(window.location.href);
+                                    previewUrl.searchParams.delete('_pjax');
+                                    previewUrl.searchParams.set('rex-api-call', 'focuspoint');
+                                    previewUrl.searchParams.set('type', this.mediatype);
+                                    previewUrl.searchParams.set('file', this.mediafile);
+                                    previewUrl.searchParams.set('xy', this.cPos.asData());
+                                    this.domPreviewImage.attr('src', previewUrl.toString());
                                 },
         setInfo             : function( pos ) {
                                     this.domInfo.html( pos.asInfo() );

--- a/assets/focuspoint.js
+++ b/assets/focuspoint.js
@@ -68,6 +68,7 @@ function fpCreateController ( container, mediafile )
                                     previewUrl.searchParams.set('type', this.mediatype);
                                     previewUrl.searchParams.set('file', this.mediafile);
                                     previewUrl.searchParams.set('xy', this.cPos.asData());
+                                    previewUrl.searchParams.set('_fpv', Date.now().toString());
                                     this.domPreviewImage.attr('src', previewUrl.toString());
                                 },
         setInfo             : function( pos ) {

--- a/assets/focuspoint.js
+++ b/assets/focuspoint.js
@@ -212,8 +212,25 @@ function fpCreateController ( container, mediafile )
     return controller;
 }
 
-$(document).ready( function() {
-    $('.focuspoint-panel[data-mediafile]').each(function() {
-        fpCreateController( $(this), $(this).data('mediafile') );
+function fpInitControllers( context )
+{
+    var root = context ? $(context) : $(document);
+    root.find('.focuspoint-panel[data-mediafile]').each(function() {
+        var panel = $(this);
+        if (panel.data('fpInitialized')) {
+            return;
+        }
+        var controller = fpCreateController( panel, panel.data('mediafile') );
+        if (controller !== null) {
+            panel.data('fpInitialized', true);
+        }
     });
+}
+
+$(document).on('rex:ready', function( event, container ) {
+    fpInitControllers(container);
+});
+
+$(function() {
+    fpInitControllers(document);
 });

--- a/assets/focuspoint.js
+++ b/assets/focuspoint.js
@@ -20,11 +20,13 @@ function fpCreatePosition( x,y )
         asCss: function () { return {'top':this.Y()+'%','left':this.X()+'%'}; },
     }
 }
+
 function fpCreatePositionFromEvent( event )
 {
     var that = $(event.currentTarget);
     return fpCreatePosition( (event.pageX - that.offset().left + 1)/that.width() * 100, (event.pageY - that.offset().top + 1)/that.height() * 100 );
 }
+
 function fpCreatePositionFromData( data )
 {
     data = data.match( /^((100|[1-9]?[0-9])[.][0-9]),((100|[1-9]?[0-9])[.][0-9])$/ );
@@ -75,7 +77,7 @@ function fpCreateController ( container, mediafile )
                                     this.setInfo( this.cPos );
                                     this.setPreview();
                                 },
-        previewToggle           : function( toggle ) {
+        previewToggle       : function( toggle ) {
                                     this.domPreviewContainer.toggleClass( 'hidden', !toggle );
                                     this.domPreviewOff.toggleClass( 'hidden', !toggle );
                                 },
@@ -84,7 +86,7 @@ function fpCreateController ( container, mediafile )
         select              : function( field ) {
                                     this.domField = field.closest( '.focuspoint-input-group' );
                                     this.domInput = this.domField.find('input');
-                                    name = this.domInput.attr('name');
+                                    var name = this.domInput.attr('name');
                                     this.oPos = this.domField.data( 'fpinitialpos' );
                                     this.cPos = fpCreatePositionFromData( this.domInput.val() );
                                     this.mediatype = this.domField.data( 'fpmediatype');
@@ -96,12 +98,17 @@ function fpCreateController ( container, mediafile )
                                     $('form .focuspoint-input-group button').removeClass( 'btn-info' );
                                     this.domField.find('button').addClass( 'btn-info' );
                                     if( this.mediatype > '' ) this.previewToggle( true );
+                                    this.domBadge.text( this.mediatype );
                                     if( this.domSelect.length > 0 ) this.domSelect.get(0).value = name;
                                 },
         set                 : function( pos ) {
                                     this.cPos = pos;
                                     this.domInput.val( pos.asData() );
                                     this.updateView();
+                                },
+        nudge               : function( x, y ) {
+                                    if( this.cPos == null ) return;
+                                    this.set( fpCreatePosition(this.cPos.x + x, this.cPos.y + y) );
                                 },
         reset               : function() {
                                     this.cPos = this.oPos;
@@ -116,12 +123,14 @@ function fpCreateController ( container, mediafile )
         startPreview        : function( mediatype ) {
                                     this.previewToggle( true );
                                     this.mediatype = mediatype;
+                                    this.domBadge.text( mediatype );
                                     this.domField.data( 'fpmediatype', mediatype );
                                     this.setPreview();
                                 },
         stopPreview         : function() {
                                     this.previewToggle( false );
                                     this.mediatype = '';
+                                    this.domBadge.text( '' );
                                     this.domField.data( 'fpmediatype', '' );
                                 },
     }
@@ -133,18 +142,19 @@ function fpCreateController ( container, mediafile )
         var ich = $(this);
         ich.data( 'fpinitialpos', fpCreatePositionFromData( ich.find('input').data( 'fpinitial' ) ) );
         ich.data( 'fpmediatype', '' );
-        ich.find('button').click( controller, function( event ) { event.data.select( $(this) ); });
-        ich.find('input').change( controller, function( event ) { event.data.select( $(this) ); });
+        ich.find('button').click( controller, function( event ) { event.preventDefault(); event.data.select( $(this) ); });
+        ich.find('input').change( controller, function( event ) { event.preventDefault(); event.data.select( $(this) ); });
     });
     if( (fieldList.length > 1 ) && (fieldList.closest('.form-group').filter('.hidden').length > 0 ) )
     {
-        container.children('.focuspoint-panel-select').find('option').click( function( event ) {
-            $('#rex-metainfo-' + $(this).attr('value') ).closest('.input-group').find('button').click();
+        controller.domSelect.on( 'change', function() {
+            $('#rex-metainfo-' + $(this).val() ).closest('.input-group').find('button').click();
         });
     }
 
     // set event-handler
-    container.find('button[data-button="zoom"]').click( function() {
+    container.find('button[data-button="zoom"]').click( function( event ) {
+            event.preventDefault();
             $(this).closest('.col-sm-4').toggleClass('col-sm-12');
         });
     controller.domImageContainer.mousemove( controller, function( event ) {
@@ -156,16 +166,41 @@ function fpCreateController ( container, mediafile )
     controller.domImageContainer.click( controller, function( event ) {
             event.data.set( fpCreatePositionFromEvent( event ) );
         });
+    controller.domImageContainer.keydown( controller, function( event ) {
+            var delta = event.shiftKey ? 2 : 0.5;
+            switch (event.key) {
+                case 'ArrowUp':
+                    event.preventDefault();
+                    event.data.nudge( 0, -delta );
+                    break;
+                case 'ArrowDown':
+                    event.preventDefault();
+                    event.data.nudge( 0, delta );
+                    break;
+                case 'ArrowLeft':
+                    event.preventDefault();
+                    event.data.nudge( -delta, 0 );
+                    break;
+                case 'ArrowRight':
+                    event.preventDefault();
+                    event.data.nudge( delta, 0 );
+                    break;
+            }
+        });
     container.find('li[data-button="reset"]').click( controller, function( event ) {
+            event.preventDefault();
             event.data.reset( );
         });
     container.find('li[data-button="remove"]').click( controller, function( event ) {
+            event.preventDefault();
             event.data.remove( );
         });
     container.find('li[data-ref]').click( controller, function( event ) {
+            event.preventDefault();
             event.data.startPreview( $(this).data('ref') );
         });
     controller.domPreviewOff.click( controller, function( event ) {
+            event.preventDefault();
             event.data.stopPreview( );
         });
 
@@ -176,3 +211,9 @@ function fpCreateController ( container, mediafile )
 
     return controller;
 }
+
+$(document).ready( function() {
+    $('.focuspoint-panel[data-mediafile]').each(function() {
+        fpCreateController( $(this), $(this).data('mediafile') );
+    });
+});

--- a/assets/focuspoint.js
+++ b/assets/focuspoint.js
@@ -51,6 +51,7 @@ function fpCreateController ( container, mediafile )
         domInfo             : container.find('small span'),
         domField            : null,
         domInput            : null,
+        zoomMode            : false,
         // internal variables
         mediafile           : mediafile,
         mediatypes          : '',
@@ -80,6 +81,14 @@ function fpCreateController ( container, mediafile )
         previewToggle       : function( toggle ) {
                                     this.domPreviewContainer.toggleClass( 'hidden', !toggle );
                                     this.domPreviewOff.toggleClass( 'hidden', !toggle );
+                                },
+        setZoomMode         : function( toggle ) {
+                                    this.zoomMode = !!toggle;
+                                    this.domContainer.toggleClass( 'focuspoint-panel-zoom', this.zoomMode );
+                                    $('body').toggleClass( 'focuspoint-overlay-open', this.zoomMode );
+                                },
+        toggleZoomMode      : function() {
+                                    this.setZoomMode( !this.zoomMode );
                                 },
 
         // Event-related functions
@@ -155,7 +164,17 @@ function fpCreateController ( container, mediafile )
     // set event-handler
         container.find('button[data-button="zoom"]').click( function( event ) {
             event.preventDefault();
-            container.toggleClass('focuspoint-panel-zoom');
+            controller.toggleZoomMode();
+        });
+    container.on('click', function( event ) {
+            if( controller.zoomMode && event.target === this ) {
+                controller.setZoomMode(false);
+            }
+        });
+    $(document).on('keydown.focuspointZoom', function( event ) {
+            if( controller.zoomMode && event.key === 'Escape' ) {
+                controller.setZoomMode(false);
+            }
         });
     controller.domImageContainer.mousemove( controller, function( event ) {
             event.data.setInfo( fpCreatePositionFromEvent( event ) );

--- a/assets/focuspoint.js
+++ b/assets/focuspoint.js
@@ -153,9 +153,9 @@ function fpCreateController ( container, mediafile )
     }
 
     // set event-handler
-    container.find('button[data-button="zoom"]').click( function( event ) {
+        container.find('button[data-button="zoom"]').click( function( event ) {
             event.preventDefault();
-            $(this).closest('.col-sm-4').toggleClass('col-sm-12');
+            container.toggleClass('focuspoint-panel-zoom');
         });
     controller.domImageContainer.mousemove( controller, function( event ) {
             event.data.setInfo( fpCreatePositionFromEvent( event ) );

--- a/assets/focuspoint.js
+++ b/assets/focuspoint.js
@@ -62,8 +62,7 @@ function fpCreateController ( container, mediafile )
                                 {
                                     if( this.domPreviewContainer.hasClass('hidden') ) return this;
                                     if( this.mediatype == '' ) { this.domPreviewOff.click(); return; }
-                                    var previewUrl = new URL(window.location.href);
-                                    previewUrl.searchParams.delete('_pjax');
+                                    var previewUrl = new URL(window.location.origin + window.location.pathname);
                                     previewUrl.searchParams.set('rex-api-call', 'focuspoint');
                                     previewUrl.searchParams.set('type', this.mediatype);
                                     previewUrl.searchParams.set('file', this.mediafile);

--- a/assets/focuspoint.min.css
+++ b/assets/focuspoint.min.css
@@ -56,5 +56,15 @@
 }
 
 .focuspoint-panel button[data-button="zoom"] .fa-search-minus { display:none; }
-.col-sm-12 .focuspoint-panel button[data-button="zoom"] .fa-search-plus { display:none; }
-.col-sm-12 .focuspoint-panel button[data-button="zoom"] .fa-search-minus { display:inline; }
+.focuspoint-panel.focuspoint-panel-zoom button[data-button="zoom"] .fa-search-plus { display:none; }
+.focuspoint-panel.focuspoint-panel-zoom button[data-button="zoom"] .fa-search-minus { display:inline; }
+
+.focuspoint-panel.focuspoint-panel-zoom {
+    position: relative;
+    z-index: 10;
+}
+
+.focuspoint-panel.focuspoint-panel-zoom > .focuspoint-panel-image > img {
+    max-height: 75vh;
+    object-fit: contain;
+}

--- a/assets/focuspoint.min.css
+++ b/assets/focuspoint.min.css
@@ -8,4 +8,53 @@
  *  For the full copyright and license information, please view the LICENSE
  *  file that was distributed with this source code.
  */
-.focuspoint-panel{width:100%}.focuspoint-panel-select>*{font-size:70%}.focuspoint-panel>.focuspoint-panel-image{padding:0;position:relative;cursor:crosshair;cursor:url(cross.png) 48 48,crosshair}.focuspoint-panel>.focuspoint-panel-image>img{width:100%;z-index:-1}.focuspoint-panel>div:last-child>img{max-width:100%;position:relative}.focuspoint-panel>.focuspoint-panel-image>div{height:99px;width:99px;background-image:url(cross.png);position:absolute;top:50%;left:50%;margin:-50px 49px 49px -50px;transition:top,left,300ms ease-in-out}.focuspoint-panel>small{display:block;text-align:center}.focuspoint-panel>small>span{display:inline-block;width:17rem;border:1px solid rgba(64,64,64,0.3);border-top:0;border-radius:0 0 1rem 1rem;background-color:rgba(128,128,128,0.3);}.focuspoint-panel button[data-button="zoom"] .fa-search-minus{display:none}.col-sm-12 .focuspoint-panel button[data-button="zoom"] .fa-search-plus{display:none}.col-sm-12 .focuspoint-panel button[data-button="zoom"] .fa-search-minus{display:inline}
+.focuspoint-panel{
+    width: 100%;
+}
+.focuspoint-panel-select > * {
+    font-size: 85%;
+}
+.focuspoint-panel > .focuspoint-panel-image {
+    padding: 0;
+    position: relative;
+    cursor: crosshair;
+    cursor: url('cross.png') 48 48, crosshair;
+    outline: 0;
+}
+.focuspoint-panel > .focuspoint-panel-image:focus {
+    box-shadow: inset 0 0 0 2px rgba(51, 122, 183, 0.8);
+}
+.focuspoint-panel  > .focuspoint-panel-image > img {
+    width: 100%;
+    z-index: -1;
+}
+.focuspoint-panel > div:last-child > img {
+    max-width: 100%;
+    position: relative;
+}
+.focuspoint-panel  > .focuspoint-panel-image > div {
+    height: 99px;
+    width: 99px;
+    background-image: url('cross.png');
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin: -50px 49px 49px -50px;
+    transition: top 300ms ease-in-out, left 300ms ease-in-out;
+}
+.focuspoint-panel > small {
+    display: block;
+    text-align: center;
+}
+.focuspoint-panel > small > span {
+    display: inline-block;
+    width: 17rem;
+    border: 1px solid rgba(64, 64, 64, 0.3);
+    border-top: 0;
+    border-radius: 0 0 1rem 1rem;
+    background-color: rgba(128, 128, 128, 0.3);
+}
+
+.focuspoint-panel button[data-button="zoom"] .fa-search-minus { display:none; }
+.col-sm-12 .focuspoint-panel button[data-button="zoom"] .fa-search-plus { display:none; }
+.col-sm-12 .focuspoint-panel button[data-button="zoom"] .fa-search-minus { display:inline; }

--- a/assets/focuspoint.min.css
+++ b/assets/focuspoint.min.css
@@ -60,11 +60,25 @@
 .focuspoint-panel.focuspoint-panel-zoom button[data-button="zoom"] .fa-search-minus { display:inline; }
 
 .focuspoint-panel.focuspoint-panel-zoom {
-    position: relative;
-    z-index: 10;
+    position: fixed;
+    top: 2vh;
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(1100px, 96vw);
+    max-height: 96vh;
+    overflow: auto;
+    background: #fff;
+    box-shadow: 0 20px 70px rgba(0, 0, 0, 0.45);
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 6px;
+    z-index: 2000;
 }
 
 .focuspoint-panel.focuspoint-panel-zoom > .focuspoint-panel-image > img {
-    max-height: 75vh;
+    max-height: 68vh;
     object-fit: contain;
+}
+
+body.focuspoint-overlay-open {
+    overflow: hidden;
 }

--- a/assets/focuspoint.min.js
+++ b/assets/focuspoint.min.js
@@ -62,13 +62,13 @@ function fpCreateController ( container, mediafile )
                                 {
                                     if( this.domPreviewContainer.hasClass('hidden') ) return this;
                                     if( this.mediatype == '' ) { this.domPreviewOff.click(); return; }
-                                    this.domPreviewImage.attr( 'src',
-                                        location.pathname +
-                                        location.search +
-                                        '&rex-api-call=focuspoint&type=' + this.mediatype +
-                                        '&file=' + this.mediafile +
-                                        '&xy=' + this.cPos.asData()
-                                    );
+                                    var previewUrl = new URL(window.location.href);
+                                    previewUrl.searchParams.delete('_pjax');
+                                    previewUrl.searchParams.set('rex-api-call', 'focuspoint');
+                                    previewUrl.searchParams.set('type', this.mediatype);
+                                    previewUrl.searchParams.set('file', this.mediafile);
+                                    previewUrl.searchParams.set('xy', this.cPos.asData());
+                                    this.domPreviewImage.attr('src', previewUrl.toString());
                                 },
         setInfo             : function( pos ) {
                                     this.domInfo.html( pos.asInfo() );

--- a/assets/focuspoint.min.js
+++ b/assets/focuspoint.min.js
@@ -68,6 +68,7 @@ function fpCreateController ( container, mediafile )
                                     previewUrl.searchParams.set('type', this.mediatype);
                                     previewUrl.searchParams.set('file', this.mediafile);
                                     previewUrl.searchParams.set('xy', this.cPos.asData());
+                                    previewUrl.searchParams.set('_fpv', Date.now().toString());
                                     this.domPreviewImage.attr('src', previewUrl.toString());
                                 },
         setInfo             : function( pos ) {

--- a/assets/focuspoint.min.js
+++ b/assets/focuspoint.min.js
@@ -212,8 +212,25 @@ function fpCreateController ( container, mediafile )
     return controller;
 }
 
-$(document).ready( function() {
-    $('.focuspoint-panel[data-mediafile]').each(function() {
-        fpCreateController( $(this), $(this).data('mediafile') );
+function fpInitControllers( context )
+{
+    var root = context ? $(context) : $(document);
+    root.find('.focuspoint-panel[data-mediafile]').each(function() {
+        var panel = $(this);
+        if (panel.data('fpInitialized')) {
+            return;
+        }
+        var controller = fpCreateController( panel, panel.data('mediafile') );
+        if (controller !== null) {
+            panel.data('fpInitialized', true);
+        }
     });
+}
+
+$(document).on('rex:ready', function( event, container ) {
+    fpInitControllers(container);
+});
+
+$(function() {
+    fpInitControllers(document);
 });

--- a/assets/focuspoint.min.js
+++ b/assets/focuspoint.min.js
@@ -8,16 +8,212 @@
  *  For the full copyright and license information, please view the LICENSE
  *  file that was distributed with this source code.
  */
- function fpCreatePosition(x,y)
- {return{x:Math.max(0,Math.min(100,x)),y:Math.max(0,Math.min(100,y)),X:function(){return this.x.toFixed(1)},Y:function(){return this.y.toFixed(1)},asData:function(){return this.X()+','+this.Y()},asInfo:function(){return this.X()+'% | '+this.Y()+'%'},asCss:function(){return{'top':this.Y()+'%','left':this.X()+'%'}},}}
- function fpCreatePositionFromEvent(event)
- {var that=$(event.currentTarget);return fpCreatePosition((event.pageX-that.offset().left+1)/that.width()*100,(event.pageY-that.offset().top+1)/that.height()*100)}
- function fpCreatePositionFromData(data)
- {data=data.match(/^((100|[1-9]?[0-9])[.][0-9]),((100|[1-9]?[0-9])[.][0-9])$/);if(data==null)return fpCreatePosition(50,50);return fpCreatePosition(data[1],data[3])}
- function fpCreateController(container,mediafile)
- {var controller={domContainer:container,domSelect:container.children('.focuspoint-panel-select').find('select'),domBadge:container.find('.badge'),domImageContainer:container.children('.focuspoint-panel-image'),domImage:container.children('.focuspoint-panel-image').find('img'),domPointer:container.children('.focuspoint-panel-image').find('div'),domPreviewContainer:container.children('div:last-child'),domPreviewImage:container.children('div:last-child').find('img'),domPreviewOff:container.find('button[data-button="schalter"]'),domPreviewSelect:container.find('.focuspoint-panel-typeselect'),domInfo:container.find('small span'),domField:null,domInput:null,mediafile:mediafile,mediatypes:'',cPos:null,oPos:null,setPreview:function()
- {if(this.domPreviewContainer.hasClass('hidden'))return this;if(this.mediatype==''){this.domPreviewOff.click();return}
- this.domPreviewImage.attr('src',location.pathname+location.search+'&rex-api-call=focuspoint&type='+this.mediatype+'&file='+this.mediafile+'&xy='+this.cPos.asData())},setInfo:function(pos){this.domInfo.html(pos.asInfo())},updateView:function(){this.domPointer.css(this.cPos.asCss());this.setInfo(this.cPos);this.setPreview()},previewToggle:function(toggle){this.domPreviewContainer.toggleClass('hidden',!toggle);this.domPreviewOff.toggleClass('hidden',!toggle)},select:function(field){this.domField=field.closest('.focuspoint-input-group');this.domInput=this.domField.find('input');name=this.domInput.attr('name');this.oPos=this.domField.data('fpinitialpos');this.cPos=fpCreatePositionFromData(this.domInput.val());this.mediatype=this.domField.data('fpmediatype');this.domContainer.find('.focuspoint-panel-enabler').removeClass('hidden');this.domPointer.removeClass('hidden');var ct=this.domPreviewSelect.find('>ul').children().addClass('hidden').filter('[data-field~="'+name+'"]').removeClass('hidden');this.domPreviewSelect.toggleClass('hidden',ct.length==0);this.updateView();$('form .focuspoint-input-group button').removeClass('btn-info');this.domField.find('button').addClass('btn-info');if(this.mediatype>'')this.previewToggle(!0);if(this.domSelect.length>0)this.domSelect.get(0).value=name},set:function(pos){this.cPos=pos;this.domInput.val(pos.asData());this.updateView()},reset:function(){this.cPos=this.oPos;this.domInput.val(this.domInput.data('fpinitial'));this.updateView()},remove:function(){this.cPos=fpCreatePosition(50,50);this.domInput.val(this.domInput.data('default'));this.updateView()},startPreview:function(mediatype){this.previewToggle(!0);this.mediatype=mediatype;this.domField.data('fpmediatype',mediatype);this.setPreview()},stopPreview:function(){this.previewToggle(!1);this.mediatype='';this.domField.data('fpmediatype','')},}
- var fieldList=$('form .focuspoint-input-group');if(fieldList.length==0)return null;fieldList.each(function(){var ich=$(this);ich.data('fpinitialpos',fpCreatePositionFromData(ich.find('input').data('fpinitial')));ich.data('fpmediatype','');ich.find('button').click(controller,function(event){event.data.select($(this))});ich.find('input').change(controller,function(event){event.data.select($(this))})});if((fieldList.length>1)&&(fieldList.closest('.form-group').filter('.hidden').length>0))
- {container.children('.focuspoint-panel-select').find('option').click(function(event){$('#rex-metainfo-'+$(this).attr('value')).closest('.input-group').find('button').click()})}
- container.find('button[data-button="zoom"]').click(function(){$(this).closest('.col-sm-4').toggleClass('col-sm-12')});controller.domImageContainer.mousemove(controller,function(event){event.data.setInfo(fpCreatePositionFromEvent(event))});controller.domImageContainer.mouseleave(controller,function(event){event.data.setInfo(event.data.cPos)});controller.domImageContainer.click(controller,function(event){event.data.set(fpCreatePositionFromEvent(event))});container.find('li[data-button="reset"]').click(controller,function(event){event.data.reset()});container.find('li[data-button="remove"]').click(controller,function(event){event.data.remove()});container.find('li[data-ref]').click(controller,function(event){event.data.startPreview($(this).data('ref'))});controller.domPreviewOff.click(controller,function(event){event.data.stopPreview()});var currentField=fieldList.find('#rex-metainfo-med_focuspoint').closest('.focuspoint-input-group');if(currentField.length==0)currentField=fieldList.first();controller.select(currentField);return controller}
+function fpCreatePosition( x,y )
+{
+    return {
+        x : Math.max( 0, Math.min( 100, x ) ),
+        y : Math.max( 0, Math.min( 100, y ) ),
+        X : function() { return this.x.toFixed(1); },
+        Y : function() { return this.y.toFixed(1); },
+        asData: function() { return this.X() + ',' + this.Y(); },
+        asInfo: function() { return this.X() + '% | ' + this.Y() + '%'; },
+        asCss: function () { return {'top':this.Y()+'%','left':this.X()+'%'}; },
+    }
+}
+
+function fpCreatePositionFromEvent( event )
+{
+    var that = $(event.currentTarget);
+    return fpCreatePosition( (event.pageX - that.offset().left + 1)/that.width() * 100, (event.pageY - that.offset().top + 1)/that.height() * 100 );
+}
+
+function fpCreatePositionFromData( data )
+{
+    data = data.match( /^((100|[1-9]?[0-9])[.][0-9]),((100|[1-9]?[0-9])[.][0-9])$/ );
+    if( data == null ) return fpCreatePosition( 50, 50 );
+    return fpCreatePosition( data[1], data[3] );
+}
+
+function fpCreateController ( container, mediafile )
+{
+    var controller = {
+        // Links to DOM-Elements
+        domContainer        : container,
+        domSelect           : container.children('.focuspoint-panel-select').find('select'),
+        domBadge            : container.find('.badge'),
+        domImageContainer   : container.children('.focuspoint-panel-image'),
+        domImage            : container.children('.focuspoint-panel-image').find('img'),
+        domPointer          : container.children('.focuspoint-panel-image').find('div'),
+        domPreviewContainer : container.children('div:last-child'),
+        domPreviewImage     : container.children('div:last-child').find('img'),
+        domPreviewOff       : container.find('button[data-button="schalter"]'),
+        domPreviewSelect    : container.find('.focuspoint-panel-typeselect'),
+        domInfo             : container.find('small span'),
+        domField            : null,
+        domInput            : null,
+        // internal variables
+        mediafile           : mediafile,
+        mediatypes          : '',
+        cPos                : null,
+        oPos                : null,
+        // Service-Functions
+        setPreview          : function()
+                                {
+                                    if( this.domPreviewContainer.hasClass('hidden') ) return this;
+                                    if( this.mediatype == '' ) { this.domPreviewOff.click(); return; }
+                                    this.domPreviewImage.attr( 'src',
+                                        location.pathname +
+                                        location.search +
+                                        '&rex-api-call=focuspoint&type=' + this.mediatype +
+                                        '&file=' + this.mediafile +
+                                        '&xy=' + this.cPos.asData()
+                                    );
+                                },
+        setInfo             : function( pos ) {
+                                    this.domInfo.html( pos.asInfo() );
+                                },
+        updateView          : function() {
+                                    this.domPointer.css( this.cPos.asCss() );
+                                    this.setInfo( this.cPos );
+                                    this.setPreview();
+                                },
+        previewToggle       : function( toggle ) {
+                                    this.domPreviewContainer.toggleClass( 'hidden', !toggle );
+                                    this.domPreviewOff.toggleClass( 'hidden', !toggle );
+                                },
+
+        // Event-related functions
+        select              : function( field ) {
+                                    this.domField = field.closest( '.focuspoint-input-group' );
+                                    this.domInput = this.domField.find('input');
+                                    var name = this.domInput.attr('name');
+                                    this.oPos = this.domField.data( 'fpinitialpos' );
+                                    this.cPos = fpCreatePositionFromData( this.domInput.val() );
+                                    this.mediatype = this.domField.data( 'fpmediatype');
+                                    this.domContainer.find('.focuspoint-panel-enabler').removeClass( 'hidden' );
+                                    this.domPointer.removeClass( 'hidden' );
+                                    var ct = this.domPreviewSelect.find('>ul').children().addClass('hidden').filter('[data-field~="'+name+'"]').removeClass('hidden');
+                                    this.domPreviewSelect.toggleClass('hidden',ct.length==0);
+                                    this.updateView();
+                                    $('form .focuspoint-input-group button').removeClass( 'btn-info' );
+                                    this.domField.find('button').addClass( 'btn-info' );
+                                    if( this.mediatype > '' ) this.previewToggle( true );
+                                    this.domBadge.text( this.mediatype );
+                                    if( this.domSelect.length > 0 ) this.domSelect.get(0).value = name;
+                                },
+        set                 : function( pos ) {
+                                    this.cPos = pos;
+                                    this.domInput.val( pos.asData() );
+                                    this.updateView();
+                                },
+        nudge               : function( x, y ) {
+                                    if( this.cPos == null ) return;
+                                    this.set( fpCreatePosition(this.cPos.x + x, this.cPos.y + y) );
+                                },
+        reset               : function() {
+                                    this.cPos = this.oPos;
+                                    this.domInput.val( this.domInput.data('fpinitial') );
+                                    this.updateView();
+                                },
+        remove              : function() {
+                                    this.cPos = fpCreatePosition( 50,50 );
+                                    this.domInput.val( this.domInput.data('default') );
+                                    this.updateView();
+                                },
+        startPreview        : function( mediatype ) {
+                                    this.previewToggle( true );
+                                    this.mediatype = mediatype;
+                                    this.domBadge.text( mediatype );
+                                    this.domField.data( 'fpmediatype', mediatype );
+                                    this.setPreview();
+                                },
+        stopPreview         : function() {
+                                    this.previewToggle( false );
+                                    this.mediatype = '';
+                                    this.domBadge.text( '' );
+                                    this.domField.data( 'fpmediatype', '' );
+                                },
+    }
+
+    // detect and prepare related input-fields, abort if none
+    var fieldList = $('form .focuspoint-input-group');
+    if( fieldList.length == 0 ) return null;
+    fieldList.each( function() {
+        var ich = $(this);
+        ich.data( 'fpinitialpos', fpCreatePositionFromData( ich.find('input').data( 'fpinitial' ) ) );
+        ich.data( 'fpmediatype', '' );
+        ich.find('button').click( controller, function( event ) { event.preventDefault(); event.data.select( $(this) ); });
+        ich.find('input').change( controller, function( event ) { event.preventDefault(); event.data.select( $(this) ); });
+    });
+    if( (fieldList.length > 1 ) && (fieldList.closest('.form-group').filter('.hidden').length > 0 ) )
+    {
+        controller.domSelect.on( 'change', function() {
+            $('#rex-metainfo-' + $(this).val() ).closest('.input-group').find('button').click();
+        });
+    }
+
+    // set event-handler
+    container.find('button[data-button="zoom"]').click( function( event ) {
+            event.preventDefault();
+            $(this).closest('.col-sm-4').toggleClass('col-sm-12');
+        });
+    controller.domImageContainer.mousemove( controller, function( event ) {
+            event.data.setInfo( fpCreatePositionFromEvent( event ) );
+        });
+    controller.domImageContainer.mouseleave( controller, function( event ) {
+            event.data.setInfo( event.data.cPos );
+        });
+    controller.domImageContainer.click( controller, function( event ) {
+            event.data.set( fpCreatePositionFromEvent( event ) );
+        });
+    controller.domImageContainer.keydown( controller, function( event ) {
+            var delta = event.shiftKey ? 2 : 0.5;
+            switch (event.key) {
+                case 'ArrowUp':
+                    event.preventDefault();
+                    event.data.nudge( 0, -delta );
+                    break;
+                case 'ArrowDown':
+                    event.preventDefault();
+                    event.data.nudge( 0, delta );
+                    break;
+                case 'ArrowLeft':
+                    event.preventDefault();
+                    event.data.nudge( -delta, 0 );
+                    break;
+                case 'ArrowRight':
+                    event.preventDefault();
+                    event.data.nudge( delta, 0 );
+                    break;
+            }
+        });
+    container.find('li[data-button="reset"]').click( controller, function( event ) {
+            event.preventDefault();
+            event.data.reset( );
+        });
+    container.find('li[data-button="remove"]').click( controller, function( event ) {
+            event.preventDefault();
+            event.data.remove( );
+        });
+    container.find('li[data-ref]').click( controller, function( event ) {
+            event.preventDefault();
+            event.data.startPreview( $(this).data('ref') );
+        });
+    controller.domPreviewOff.click( controller, function( event ) {
+            event.preventDefault();
+            event.data.stopPreview( );
+        });
+
+    // activate default-Field or (if missing) first in the list
+    var currentField = fieldList.find('#rex-metainfo-med_focuspoint').closest('.focuspoint-input-group');
+    if( currentField.length == 0 ) currentField = fieldList.first();
+    controller.select( currentField );
+
+    return controller;
+}
+
+$(document).ready( function() {
+    $('.focuspoint-panel[data-mediafile]').each(function() {
+        fpCreateController( $(this), $(this).data('mediafile') );
+    });
+});

--- a/assets/focuspoint.min.js
+++ b/assets/focuspoint.min.js
@@ -51,6 +51,7 @@ function fpCreateController ( container, mediafile )
         domInfo             : container.find('small span'),
         domField            : null,
         domInput            : null,
+        zoomMode            : false,
         // internal variables
         mediafile           : mediafile,
         mediatypes          : '',
@@ -80,6 +81,14 @@ function fpCreateController ( container, mediafile )
         previewToggle       : function( toggle ) {
                                     this.domPreviewContainer.toggleClass( 'hidden', !toggle );
                                     this.domPreviewOff.toggleClass( 'hidden', !toggle );
+                                },
+        setZoomMode         : function( toggle ) {
+                                    this.zoomMode = !!toggle;
+                                    this.domContainer.toggleClass( 'focuspoint-panel-zoom', this.zoomMode );
+                                    $('body').toggleClass( 'focuspoint-overlay-open', this.zoomMode );
+                                },
+        toggleZoomMode      : function() {
+                                    this.setZoomMode( !this.zoomMode );
                                 },
 
         // Event-related functions
@@ -155,7 +164,17 @@ function fpCreateController ( container, mediafile )
     // set event-handler
         container.find('button[data-button="zoom"]').click( function( event ) {
             event.preventDefault();
-            container.toggleClass('focuspoint-panel-zoom');
+            controller.toggleZoomMode();
+        });
+    container.on('click', function( event ) {
+            if( controller.zoomMode && event.target === this ) {
+                controller.setZoomMode(false);
+            }
+        });
+    $(document).on('keydown.focuspointZoom', function( event ) {
+            if( controller.zoomMode && event.key === 'Escape' ) {
+                controller.setZoomMode(false);
+            }
         });
     controller.domImageContainer.mousemove( controller, function( event ) {
             event.data.setInfo( fpCreatePositionFromEvent( event ) );

--- a/assets/focuspoint.min.js
+++ b/assets/focuspoint.min.js
@@ -153,9 +153,9 @@ function fpCreateController ( container, mediafile )
     }
 
     // set event-handler
-    container.find('button[data-button="zoom"]').click( function( event ) {
+        container.find('button[data-button="zoom"]').click( function( event ) {
             event.preventDefault();
-            $(this).closest('.col-sm-4').toggleClass('col-sm-12');
+            container.toggleClass('focuspoint-panel-zoom');
         });
     controller.domImageContainer.mousemove( controller, function( event ) {
             event.data.setInfo( fpCreatePositionFromEvent( event ) );

--- a/assets/focuspoint.min.js
+++ b/assets/focuspoint.min.js
@@ -62,8 +62,7 @@ function fpCreateController ( container, mediafile )
                                 {
                                     if( this.domPreviewContainer.hasClass('hidden') ) return this;
                                     if( this.mediatype == '' ) { this.domPreviewOff.click(); return; }
-                                    var previewUrl = new URL(window.location.href);
-                                    previewUrl.searchParams.delete('_pjax');
+                                    var previewUrl = new URL(window.location.origin + window.location.pathname);
                                     previewUrl.searchParams.set('rex-api-call', 'focuspoint');
                                     previewUrl.searchParams.set('type', this.mediatype);
                                     previewUrl.searchParams.set('file', this.mediafile);

--- a/fragments/fp_panel.php
+++ b/fragments/fp_panel.php
@@ -32,7 +32,7 @@ use rex_media_manager;
 
 /** @var rex_fragment $this */
 ?>
-<div id="focuspoint-panel" class="focuspoint-panel panel panel-default">
+<div id="focuspoint-panel" class="focuspoint-panel panel panel-default" data-mediafile="<?= $this->mediafile ?>">
     <div class="panel-heading"><?= rex_i18n::msg('focuspoint_detail_header') ?></div>
 <?php
 $mediatypes = '';
@@ -56,9 +56,12 @@ if (isset($this->fieldselect) && \is_array($this->fieldselect)) {
     </div>
 <?php
 }
+
+$media = rex_media::get($this->mediafile);
+$buster = null !== $media ? $media->getUpdateDate() : time();
 ?>
-    <div class="focuspoint-panel-image">
-        <img src="<?= rex_media_manager::getUrl(rex_effect_abstract_focuspoint::MM_TYPE, $this->mediafile, rex_media::get($this->mediafile)->getUpdateDate()) ?>">
+    <div class="focuspoint-panel-image" tabindex="0" role="button" aria-label="<?= rex_i18n::msg('focuspoint_detail_image_aria') ?>">
+        <img alt="focuspoint-source" src="<?= rex_media_manager::getUrl(rex_effect_abstract_focuspoint::MM_TYPE, $this->mediafile, $buster) ?>">
         <div class="focuspoint-panel-enabler hidden"></div>
     </div>
     <small class="focuspoint-panel-enabler hidden"><span></span></small>
@@ -70,14 +73,14 @@ if (isset($this->fieldselect) && \is_array($this->fieldselect)) {
                 <li data-button="remove"><a class="dropdown-item" href="#"><?= rex_i18n::msg('focuspoint_detail_remove') ?></a></li>
             </ul>
         </div>
-        <button type="button" class="btn btn-primary btn-sm" data-button="zoom" ><i class="rex-icon fa-search-plus"></i><i class="rex-icon fa-search-minus"></i></button>
+        <button type="button" class="btn btn-primary btn-sm" data-button="zoom" title="<?= rex_i18n::msg('focuspoint_detail_zoom_toggle') ?>" aria-label="<?= rex_i18n::msg('focuspoint_detail_zoom_toggle') ?>"><i class="rex-icon fa-search-plus"></i><i class="rex-icon fa-search-minus"></i></button>
 <?php
 if ('' < $mediatypes) {
 ?>
         <div class="focuspoint-panel-typeselect btn-group">
             <button type="button" class="btn btn-default  btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><?= rex_i18n::msg('focuspoint_detail_preview') ?> <span class="badge"></span> <span class="caret"></span></button>
             <ul class="dropdown-menu"><?= $mediatypes ?></ul>
-            <button type="button" data-button="schalter" class="btn btn-default hidden btn-sm"><i class="rex-icon fa-times"></i></button>
+            <button type="button" data-button="schalter" class="btn btn-default hidden btn-sm" title="<?= rex_i18n::msg('focuspoint_detail_close_preview') ?>" aria-label="<?= rex_i18n::msg('focuspoint_detail_close_preview') ?>"><i class="rex-icon fa-times"></i></button>
         </div>
 <?php } ?>
     </div>
@@ -85,13 +88,7 @@ if ('' < $mediatypes) {
 if ('' < $mediatypes) {
 ?>
     <div class="hidden panel-body">
-        <img >
+        <img alt="focuspoint-preview">
     </div>
 <?php } ?>
 </div>
-
-<script type="text/javascript">
-    $(document).ready( function() {
-        fpCreateController( $('#focuspoint-panel'), "<?= $this->mediafile ?>" );
-    });
-</script>

--- a/help.php
+++ b/help.php
@@ -97,7 +97,7 @@ if( !class_exists('help_documentation') )
                 unset( $this->navigation['permissions'] );
                 foreach( $permissions as $k=>$v ) {
                     foreach( (array) $v as $perm ) {
-                        if( $perm && !$user->hasPerm($perm) ) {
+                        if( $perm && (null === $user || !$user->hasPerm($perm)) ) {
                             $this->prohibited[] = $k;
                         }
                     }
@@ -106,13 +106,13 @@ if( !class_exists('help_documentation') )
 
             foreach( $this->navigation as $k1=>$v1 ) {
                 $permission = $v1['perm'] ?? '';
-                if( $permission && !$user->hasPerm($permission) ) {
+                if( $permission && (null === $user || !$user->hasPerm($permission)) ) {
                     $this->prohibited[] = $v1['path'];
                     unset( $this->navigation[$k1] );
                 }
                 foreach( ($v1['subnav'] ?? []) as $k2=>$v2 ) {
                     $subPermission = $v2['perm'] ?? $permission;
-                    if( $subPermission && !$user->hasPerm($subPermission) ) {
+                    if( $subPermission && (null === $user || !$user->hasPerm($subPermission)) ) {
                         $this->prohibited[] = $v2['path'];
                         unset( $this->navigation[$k1][$k2] );
                     }
@@ -224,7 +224,10 @@ if( !class_exists('help_documentation') )
         {
             \rex_response::cleanOutputBuffers();
             if ( ($path = $this->getFilePath()) && \rex_media::isDocType($this->filetype) ) {
-                $mime = \rex_file::mimeType( $path );
+                $mime = (string) \rex_file::mimeType( $path );
+                if ('' === $mime) {
+                    $mime = 'application/octet-stream';
+                }
                 if( 'image/' === substr($mime,0,6) ) {
                     \rex_response::sendFile( $path, $mime );
                 } else {
@@ -245,7 +248,7 @@ if( !class_exists('help_documentation') )
 
         function stripGithubNavigation( string $text ): string
         {
-            return preg_replace( '/^(\>\s+\-\s?.*?\\n)*\s*\\n/', '', $text );
+            return (string) preg_replace( '/^(\>\s+\-\s?.*?\\n)*\s*\\n/', '', $text );
         }
 
         //  Im Text werden alle Links, die nicht Datei-intern (#...) und nicht URIs (z.B. http://...)
@@ -270,7 +273,7 @@ if( !class_exists('help_documentation') )
                     $marker = '<!--' . md5($matches[0]) . '-->';
                     $original["/$marker/"] = $matches[0];
                     return $marker;
-                }, $text );
+                }, $text ) ?? $text;
 
             # Links umbauen; nur Markdown! [label](link) bzw. ![label](link)
             $text = preg_replace_callback (
@@ -307,11 +310,11 @@ if( !class_exists('help_documentation') )
                         ['source'=>$matches[0],'label'=>$matches[3],'link'=>$matches[4],'href'=>$href,'isImageLink'=>($matches[2]>''),'context'=>$this->context]
                     ));
                 },
-                $text );
+                $text ) ?? $text;
 
             # Code-Blöcke wieder einfügen
             if( $original ) {
-                $text = preg_replace( array_keys($original), $original, $text );
+                $text = preg_replace( array_keys($original), $original, $text ) ?? $text;
             }
 
             return $text;
@@ -327,10 +330,10 @@ if( !class_exists('help_documentation') )
         {
             $url = '';
             if( preg_match('/^(?<link>.*?)(#(?<hook>.*?))?$$/',$link,$linkinfo) ){
-                if( $linkinfo['link'] ?? '' ) $request['doc'] .= DIRECTORY_SEPARATOR . $linkinfo['link'];
+                if( '' !== $linkinfo['link'] ) $request['doc'] .= DIRECTORY_SEPARATOR . $linkinfo['link'];
                 if( isset($request['_pjax']) ) unset($request['_pjax']);
                 $url = \rex_url::currentBackendPage( $request,false );
-                if( $linkinfo['hook'] ?? '' ) $url .= '#' . $linkinfo['hook'];
+                if( isset($linkinfo['hook']) && '' !== $linkinfo['hook'] ) $url .= '#' . $linkinfo['hook'];
                 $docfile = $request['doc'];
             }
             return $url;
@@ -456,6 +459,10 @@ if( !class_exists('help_documentation') )
 
         function getJsCss( ): string
         {
+            if (!$this->context instanceof \rex_addon) {
+                return '';
+            }
+
             $HTML = '';
             $path = $this->context->getAssetsPath('help.min.js');
             if( file_exists($path) ){
@@ -493,7 +500,7 @@ if( '' === ($path = $publish->getFilePath()) ) {
 
 } else {
 
-    $text = \rex_file::get( $path );
+    $text = (string) \rex_file::get( $path );
 
     $text = $publish->stripGithubNavigation( $text );
     $text = $publish->replaceLinks( $text );

--- a/install.php
+++ b/install.php
@@ -171,12 +171,16 @@ if ('' < $meta_action_type && '' === $message) {
 }
 
 if ($meta_action_field && '' === $message) {
-    $result = rex_metainfo_add_field('translate:focuspoint_field_label', rex_effect_abstract_focuspoint::MED_DEFAULT, 0, '', $meta_type_id, '', '', '', '');
-    if (true === $result) {
+    if (!is_numeric($meta_type_id)) {
+        $message = rex_i18n::rawMsg('focuspoint_install_type_error', rex_effect_abstract_focuspoint::META_FIELD_TYPE, '<strong><i>invalid type id</i></strong>');
+    } else {
+        $result = rex_metainfo_add_field('translate:focuspoint_field_label', rex_effect_abstract_focuspoint::MED_DEFAULT, 0, '', (int) $meta_type_id, '', '', '', '');
+    }
+    if (isset($result) && true === $result) {
         $successMsg[] = rex_i18n::msg('focuspoint_install_field_ok', rex_effect_abstract_focuspoint::MED_DEFAULT);
         $meta_action_connect = false; // impliziet beim Anlegen durchgeführt
         $meta_action_media = false; // impliziet beim Anlegen durchgeführt
-    } else {
+    } elseif ('' === $message) {
         $message = rex_i18n::rawMsg('focuspoint_install_field_error', rex_effect_abstract_focuspoint::MED_DEFAULT, "<strong><i>$result</i></strong>");
     }
 }

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -27,6 +27,11 @@ focuspoint_uninstall_metafields = Zusätzliche Metafelder des Typs "{0}". Das Ad
 focuspoint_uninstall_external_effects = Zusätzliche Fokuspunkt-Effekte. Das AddOn kann erst gelöscht werden, wenn die Effekte deaktiviert sind.
 focuspoint_uninstall_effects_in_use = Betroffene Media-Manager-Typen:
 focuspoint_uninstall_dependencies = Abhängigkeiten zwischen dem Focuspoint-AddOn und anderen Bereichen!
+focuspoint_uninstall_effects_migrated = {0} Focuspoint-Effekt(e) wurden aus Media-Manager-Typen entfernt.
+focuspoint_uninstall_effects_skipped = {0} Focuspoint-Effekt(e) konnten nicht automatisch entfernt werden. Diese Effekte bitte manuell löschen.
+focuspoint_uninstall_effects_cleanup_noop = Keine aktiven Fokuspunkt-Effekte gefunden. Du kannst die Deinstallation erneut starten.
+focuspoint_uninstall_offer_cleanup_button = Focuspoint-Effekte entfernen
+focuspoint_uninstall_offer_cleanup_hint = Danach die Deinstallation erneut ausführen.
 focuspoint_activate_dependencies = Fehlende Komponenten; Re-Install erforderlich!
 focuspoint_deactivate_dependencies = Abhängigkeiten zwischen dem Focuspoint-AddOn und anderen Bereichen!
 # update.php : taken from from previous version before 2.0.
@@ -67,6 +72,9 @@ focuspoint_detail_reset = Zurücksetzen
 focuspoint_detail_initial = Ausgangswert
 focuspoint_detail_remove = Entfernen
 focuspoint_detail_select = Fokus-Feld
+focuspoint_detail_zoom_toggle = Zoomansicht umschalten
+focuspoint_detail_close_preview = Vorschau schließen
+focuspoint_detail_image_aria = Fokuspunkt per Klick oder Pfeiltasten setzen
 
 #
 # page=metainfo/media -> is_in_use-check

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -27,6 +27,11 @@ focuspoint_uninstall_metafields = Additional meta-fields of type "{0}" found. Fi
 focuspoint_uninstall_external_effects = Additional focuspoint-effects found. First deacticate these effects, then try again to delete the Focuspoint-AddOn..
 focuspoint_uninstall_effects_in_use = Affected Media-Manager-Types:
 focuspoint_uninstall_dependencies = Dependencies between Focuspoint-AddOn and other AddOns!
+focuspoint_uninstall_effects_migrated = {0} focuspoint effect(s) were removed from Media Manager types.
+focuspoint_uninstall_effects_skipped = {0} focuspoint effect(s) could not be removed automatically. Please delete these effects manually.
+focuspoint_uninstall_effects_cleanup_noop = No active focuspoint effects found. You can retry uninstall now.
+focuspoint_uninstall_offer_cleanup_button = Remove focuspoint effects
+focuspoint_uninstall_offer_cleanup_hint = Run uninstall again afterwards.
 focuspoint_activate_dependencies = Components missing; re-install required!
 focuspoint_deactivate_dependencies = Dependencies between Focuspoint-AddOn and other AddOns!
 # update.php : taken from from previous version before 2.0.
@@ -67,6 +72,9 @@ focuspoint_detail_reset = Reset
 focuspoint_detail_initial = Initial value
 focuspoint_detail_remove = Remove
 focuspoint_detail_select = Focuspoint-Field
+focuspoint_detail_zoom_toggle = Toggle zoom view
+focuspoint_detail_close_preview = Close preview
+focuspoint_detail_image_aria = Set focuspoint by click or arrow keys
 
 #
 # page=metainfo/media -> is_in_use-check

--- a/lib/FocuspointReflection.php
+++ b/lib/FocuspointReflection.php
@@ -22,6 +22,7 @@ namespace FriendsOfRedaxo\Focuspoint;
 
 use ReflectionClass;
 
+/** @extends ReflectionClass<object> */
 class FocuspointReflection extends ReflectionClass
 {
     /**

--- a/lib/effect_abstract_focuspoint.php
+++ b/lib/effect_abstract_focuspoint.php
@@ -54,7 +54,10 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
     {
         $i = preg_match_all(self::PATTERN, $xy, $tags);
         if (0 < $i) {
-            $xy = [min(100, max(0, $tags['x'][0])), min(100, max(0, $tags['y'][0]))];
+            $xy = [
+                (float) min(100.0, max(0.0, (float) $tags['x'][0])),
+                (float) min(100.0, max(0.0, (float) $tags['y'][0])),
+            ];
             if (is_array($wh)) {
                 $xy = self::rel2px($xy, $wh);
             }
@@ -132,7 +135,7 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
      *
      *  @return array<float>                  [x,y] als Koordinaten-Array
      */
-    public function getFocus($media = null, ?array $default = null, ?array $wh = null)
+    public function getFocus(?FocuspointMedia $media = null, ?array $default = null, ?array $wh = null)
     {
         $xy = rex_request(self::URL_KEY, 'string', null);
         if (is_string($xy)) {
@@ -140,13 +143,13 @@ abstract class rex_effect_abstract_focuspoint extends rex_effect_abstract
             // hier eingebaut zur Funktionsfähigkeit von focuspoint_api
             $fp = self::str2fp($xy);
             if (false === $fp) {
-                $fp = null !== $media && is_a($media, FocuspointMedia::class)
+                $fp = null !== $media
                     ? $media->getFocus($xy, $default) // $xy = Meta-Feld-Name??
                     : $this->getDefaultFocus($default);
             }
         } else {
             // Standard
-            $fp = null !== $media && is_a($media, FocuspointMedia::class)
+            $fp = null !== $media
                 ? $media->getFocus($this->getMetaField(), $default)
                 : $this->getDefaultFocus($default);
         }

--- a/lib/effect_focuspoint_fit.php
+++ b/lib/effect_focuspoint_fit.php
@@ -78,8 +78,11 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
         */
         $this->media->asImage();
         $gdimage = $this->media->getImage();
-        $sw = $this->media->getWidth();
-        $sh = $this->media->getHeight();
+        $sw = (int) $this->media->getWidth();
+        $sh = (int) $this->media->getHeight();
+        if ($sw < 1 || $sh < 1) {
+            return;
+        }
         $sr = $sw / $sh;
 
         /*
@@ -146,6 +149,9 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
         */
         $dw = null === $dw ? $dh * $sr : $dw;
         $dh = null === $dh ? $dw / $sr : $dh;
+        if ($dw < 1 || $dh < 1) {
+            return;
+        }
         $dr = $dw / $dh;
         $too_wide = ($sr >= $dr);
 
@@ -190,6 +196,15 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
             $cw = floor($cw * $faktor);
             $ch = floor($ch * $faktor);
         }
+
+        if ($cw < 1 || $ch < 1) {
+            return;
+        }
+
+        $targetWidth = max(1, (int) round($dw));
+        $targetHeight = max(1, (int) round($dh));
+        $cropWidth = max(1, (int) round($cw));
+        $cropHeight = max(1, (int) round($ch));
         /*
             Den Bildauschnitt positionieren:
 
@@ -208,9 +223,9 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
             Ausgabe der Grafik
         */
         if (function_exists('ImageCreateTrueColor')) {
-            $des = @imagecreatetruecolor((int) $dw, (int) $dh);
+            $des = @imagecreatetruecolor($targetWidth, $targetHeight);
         } else {
-            $des = @imagecreate((int) $dw, (int) $dh);
+            $des = @imagecreate($targetWidth, $targetHeight);
         }
 
         if (false === $des) {
@@ -225,7 +240,7 @@ class rex_effect_focuspoint_fit extends rex_effect_abstract_focuspoint
         // @phpstan-ignore-next-line
         imagecopyresampled($des, $gdimage,
             0, 0, (int) $cx, (int) $cy,
-            (int) $dw, (int) $dh, (int) $cw, (int) $ch);
+            $targetWidth, $targetHeight, $cropWidth, $cropHeight);
 
         // @phpstan-ignore-next-line
         $this->media->setImage($des);

--- a/lib/focuspoint.php
+++ b/lib/focuspoint.php
@@ -21,6 +21,7 @@ namespace FriendsOfRedaxo\Focuspoint;
 use PDO;
 use rex;
 use rex_effect_abstract_focuspoint;
+use rex_effect_abstract;
 use rex_extension;
 use rex_extension_point;
 use rex_fragment;
@@ -30,6 +31,7 @@ use rex_sql;
 use rex_url;
 
 use function count;
+use function json_decode;
 use function strlen;
 
 use const ARRAY_FILTER_USE_KEY;
@@ -189,7 +191,7 @@ class Focuspoint
      *
      *  @return string
      */
-    public static function checkUninstallDependencies()
+    public static function checkUninstallDependencies(bool $includeEffectsInUse = true)
     {
         $message = '';
 
@@ -202,10 +204,12 @@ class Focuspoint
         }
 
         // ermittle alle Effekte der Liste, die im Media-Manager genutzt werden
-        $mmEffekteMsg = self::getFocuspointEffectsInUse();
-        if (0 < count($mmEffekteMsg)) {
-            $mmEffekteMsg = self::getFocuspointEffectsInUseMessage($mmEffekteMsg);
-            $message .= "<li>$mmEffekteMsg</li>";
+        if ($includeEffectsInUse) {
+            $mmEffekteMsg = self::getFocuspointEffectsInUse();
+            if (0 < count($mmEffekteMsg)) {
+                $mmEffekteMsg = self::getFocuspointEffectsInUseMessage($mmEffekteMsg) . self::getUninstallCleanupOffer();
+                $message .= '<li>' . rex_i18n::msg('focuspoint_uninstall_effects_in_use') . $mmEffekteMsg . '</li>';
+            }
         }
 
         if ('' < $message) {
@@ -341,14 +345,15 @@ class Focuspoint
      *  rex_effect_abstract_focuspoint erzeugt und nutze das Parameterfeld "meta".
      *
      *  @param  string $feld  Name des Fokuspunkt-Metafeldes
-     *  @return array<mixed>  Array mit einem Subarray je Type/Effekt mit
+    *  @return array<int,array<string,mixed>>  Array mit einem Subarray je Type/Effekt mit
      *                          name        => Name des Typ
      *                          type_id     => id des Typs "name" (rex_media_manager_type)
      *                          effect      => Name des eingesetzten Fokuspunkt-Effektes
      *                          id          => id des effektes (rex_media_manager_type_effect)
      *                          parameters  => Parameter des Effektes
+    *  @phpstan-return array<int,array<string,mixed>>
      */
-    public static function getFocuspointMetafieldInUse($feld)
+    public static function getFocuspointMetafieldInUse(string $feld): array
     {
         $effects = self::getFocuspointEffectsInUse();
         foreach ($effects as $k => $v) {
@@ -425,6 +430,9 @@ class Focuspoint
             /** @var non-falsy-string $target */
             $target = "rex_effect_{$effect['effect']}";
             $name = new $target();
+            if (!$name instanceof rex_effect_abstract) {
+                continue;
+            }
             $message .= '<li>' . rex_i18n::rawMsg(
                 'focuspoint_isinuse_entry',
                 $effect['name'],
@@ -447,5 +455,53 @@ class Focuspoint
             $message = "<ul>$message</ul>";
         }
         return $message;
+    }
+
+    /**
+     * Entfernt aktive Fokuspunkt-Effekte aus Media-Manager-Typen.
+     *
+     * Das wird als bewusste Bereinigungsaktion vor der Deinstallation genutzt,
+     * wenn der Anwender Fokuspunkt absichtlich entfernen moechte.
+     *
+     * @return array{converted: int, skipped: int}
+     */
+    public static function migrateEffectsToResizeFallback()
+    {
+        $effects = self::getFocuspointEffectsInUse();
+        if (0 === count($effects)) {
+            return ['converted' => 0, 'skipped' => 0];
+        }
+
+        $sql = rex_sql::factory();
+        $converted = 0;
+        $skipped = 0;
+
+        foreach ($effects as $effect) {
+            try {
+                $sql->setTable(rex::getTable('media_manager_type_effect'));
+                $sql->setWhere('id=:id', [':id' => $effect['id']]);
+                $sql->delete();
+                ++$converted;
+            } catch (\Throwable $e) {
+                ++$skipped;
+            }
+        }
+
+        return ['converted' => $converted, 'skipped' => $skipped];
+    }
+
+    /**
+     * @return string
+     */
+    private static function getUninstallCleanupOffer()
+    {
+        $url = rex_url::backendController([
+            'page' => 'packages',
+            'package' => 'focuspoint',
+            'rex-api-call' => 'focuspoint_package',
+            'function' => 'cleanup_focuspoint_effects',
+        ]);
+
+        return '<p><a class="btn btn-xs btn-primary" href="' . $url . '">' . rex_i18n::msg('focuspoint_uninstall_offer_cleanup_button') . '</a> ' . rex_i18n::msg('focuspoint_uninstall_offer_cleanup_hint') . '</p>';
     }
 }

--- a/lib/focuspoint_api.php
+++ b/lib/focuspoint_api.php
@@ -44,6 +44,10 @@ class rex_api_focuspoint extends rex_api_function
      */
     public function execute()
     {
+        // Ensure focuspoint effects are registered in this API context as well.
+        include_once __DIR__ . '/effect_abstract_focuspoint.php';
+        include_once __DIR__ . '/effect_focuspoint_fit.php';
+        rex_media_manager::addEffect(rex_effect_focuspoint_fit::class);
 
         $mediafile = rex_request('file', 'string', '');
         $mediatype = rex_request('type', 'string', '');

--- a/lib/focuspoint_api.php
+++ b/lib/focuspoint_api.php
@@ -70,7 +70,7 @@ class FocuspointMediaManager extends rex_media_manager
      *
      *  @return rex_managed_media   Ergebnisbild
      */
-    public static function createMedia($type = null, $file = null)
+    public static function createMedia(string $type, string $file)
     {
         $mediaPath = rex_path::media($file);
         $media = new rex_managed_media($mediaPath);

--- a/lib/package_api.php
+++ b/lib/package_api.php
@@ -43,9 +43,26 @@ class rex_api_focuspoint_package extends rex_api_package
     public function execute()
     {
         $function = strtolower(rex_request('function', 'string'));
-        if (!in_array($function, ['install', 'uninstall', 'activate', 'deactivate', 'delete'], true)) {
+        if (!in_array($function, ['install', 'uninstall', 'activate', 'deactivate', 'delete', 'cleanup_focuspoint_effects'], true)) {
             throw new rex_api_exception('Unknown package function "' . $function . '"!');
         }
+
+        if ('cleanup_focuspoint_effects' === $function) {
+            $migration = \FriendsOfRedaxo\Focuspoint\Focuspoint::migrateEffectsToResizeFallback();
+            $messages = [];
+            if (0 < $migration['converted']) {
+                $messages[] = rex_i18n::msg('focuspoint_uninstall_effects_migrated', $migration['converted']);
+            }
+            if (0 < $migration['skipped']) {
+                $messages[] = rex_i18n::msg('focuspoint_uninstall_effects_skipped', $migration['skipped']);
+            }
+            if (0 === count($messages)) {
+                $messages[] = rex_i18n::msg('focuspoint_uninstall_effects_cleanup_noop');
+            }
+
+            return new rex_api_result(true, implode('<br>', $messages));
+        }
+
         $packageId = rex_request('package', 'string');
         $package = rex_package::get($packageId);
         if ('uninstall' === $function && !$package->isInstalled()

--- a/uninstall.php
+++ b/uninstall.php
@@ -29,6 +29,7 @@ namespace FriendsOfRedaxo\Focuspoint;
 use rex;
 use rex_addon;
 use rex_effect_abstract_focuspoint;
+use rex_i18n;
 use rex_media_manager;
 use rex_sql;
 
@@ -37,7 +38,19 @@ use function count;
 /** @var rex_addon $this */
 
 // make addon-parameters available
-include_once 'lib/effect_focuspoint.php';
+include_once 'lib/effect_abstract_focuspoint.php';
+
+$migration = Focuspoint::migrateEffectsToResizeFallback();
+$messages = [];
+if (0 < $migration['converted']) {
+    $messages[] = rex_i18n::msg('focuspoint_uninstall_effects_migrated', $migration['converted']);
+}
+if (0 < $migration['skipped']) {
+    $messages[] = rex_i18n::msg('focuspoint_uninstall_effects_skipped', $migration['skipped']);
+}
+if (0 < count($messages)) {
+    $this->setProperty('successmsg', '<ul><li>' . implode('</li><li>', $messages) . '</li></ul>');
+}
 
 $sql = rex_sql::factory();
 
@@ -49,7 +62,7 @@ $qry = 'SELECT id FROM ' . rex::getTable('metainfo_type') . ' WHERE label=:label
 $typeId = $sql->getArray($qry, [':label' => rex_effect_abstract_focuspoint::META_FIELD_TYPE]);
 
 if (0 < count($typeId)) {
-    rex_metainfo_delete_field_type($typeId[0]['id']);
+    rex_metainfo_delete_field_type((int) $typeId[0]['id']);
 }
 
 // remove media-manager-type

--- a/update.php
+++ b/update.php
@@ -40,7 +40,7 @@ if (rex_version::compare($this->getVersion(), '2.0', '<')) {
     rex_i18n::addDirectory(__DIR__ . '/lang');
 
     // prerequisites, to fetch predefined strings
-    include_once 'lib/effect_focuspoint.php';
+    include_once 'lib/effect_abstract_focuspoint.php';
 
     $sql = rex_sql::factory();
     /**
@@ -75,7 +75,7 @@ if (rex_version::compare($this->getVersion(), '2.0', '<')) {
             }
         } else {
             // field does not exist. Add field
-            $result = rex_metainfo_add_field('translate:focuspoint_field_label', rex_effect_abstract_focuspoint::MED_DEFAULT, 3, '', $type_id, '', '', '', '');
+            $result = rex_metainfo_add_field('translate:focuspoint_field_label', rex_effect_abstract_focuspoint::MED_DEFAULT, 3, '', (int) $type_id, '', '', '', '');
             if (true !== $result) {
                 $message = rex_i18n::msg('focuspoint_install_field_error', rex_effect_abstract_focuspoint::MED_DEFAULT, "<strong><i>$result</i></strong>");
             }
@@ -109,8 +109,8 @@ if (rex_version::compare($this->getVersion(), '2.0', '<')) {
                     $liste = $sql->getArray($qry, [], PDO::FETCH_KEY_PAIR);
                     foreach ($liste as $k => $v) {
                         if (0 < preg_match_all('/(?<x>[+-]?[0-1][.][0-9]{2}),(?<y>[+-]?[0-1][.][0-9]{2})/', $v, $tags)) {
-                            $x = ($tags['x'][0] + 1) * 50;
-                            $y = (1 - $tags['y'][0]) * 50;
+                            $x = ((float) $tags['x'][0] + 1.0) * 50.0;
+                            $y = (1.0 - (float) $tags['y'][0]) * 50.0;
                             $x = max(0, min(100, $x));
                             $y = max(0, min(100, $y));
                             $sql->setTable($tab);
@@ -153,8 +153,7 @@ if (rex_version::compare($this->getVersion(), '2.0', '<')) {
                             unset($v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_fp']);
                         }
                         if (isset($v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom']) &&
-                            0 < preg_match('(0%|25%|50%|75%|100%)', $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom'], $match) &&
-                            0 < count($match)) {
+                            0 < preg_match('(0%|25%|50%|75%|100%)', $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom'], $match)) {
                             $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom'] = $match[0];
                         } else {
                             $v['rex_effect_focuspoint_fit']['rex_effect_focuspoint_fit_zoom'] = '0%';


### PR DESCRIPTION
## Ziel
Dieses PR verbessert das Focuspoint-Addon in drei Bereichen:

1. UX im Fokuspunkt-Panel
2. Deinstallations-Flow mit expliziter Bereinigungsaktion
3. Statische Analyse (Rexstan) ohne Fehler

## Änderungen
- Fokuspunkt-Panel überarbeitet:
  - robustere Event-Logik
  - bessere Accessibility (ARIA/Keyboard)
  - Initialisierung ohne Inline-Script
  - CSS-Feinschliff
- Deinstallation bleibt blockiert, wenn Focuspoint-Effekte noch im Media Manager verwendet werden.
- In der Blocker-Meldung wird eine konkrete Bereinigungsaktion angeboten.
- Bereinigungsaktion entfernt Focuspoint-Effekte aus betroffenen Media-Manager-Typen (bewusster Remove-Flow).
- Package-API um Cleanup-Funktion ergänzt.
- Sprachdateien (de/en) für neue UI- und Cleanup-Meldungen ergänzt.
- Diverse Typ-/Null-Safety- und API-Signatur-Fixes in mehreren Dateien.

## Qualitätssicherung
- Rexstan-Analyse für das Addon ausgeführt:
  - `php redaxo/bin/console rexstan:analyze redaxo/src/addons/focuspoint`
  - Ergebnis: **OK, keine Fehler**

## Hinweis zum Verhalten
Der Cleanup vor Deinstallation löscht bewusst die Focuspoint-Effekte in Media-Manager-Typen, statt auf einen Ersatz-Effekt umzuschreiben.