### PR TITLE
Fix PHP 8.5 deprecation: drop no-op setAccessible() calls

### DIFF
--- a/lib/FocuspointReflection.php
+++ b/lib/FocuspointReflection.php
@@ -48,7 +48,6 @@ class FocuspointReflection extends ReflectionClass
     public function executeMethod($method, array $params)
     {
         $method = $this->getMethod($method);
-        $method->setAccessible(true);
         return $method->invokeArgs($this->obj, $params);
     }
 
@@ -60,7 +59,6 @@ class FocuspointReflection extends ReflectionClass
     public function getPropertyValue($prop)
     {
         $property = $this->getProperty($prop);
-        $property->setAccessible(true);
         return $property->getValue($this->obj);
     }
 
@@ -73,7 +71,6 @@ class FocuspointReflection extends ReflectionClass
     public function setPropertyValue($prop, $value)
     {
         $property = $this->getProperty($prop);
-        $property->setAccessible(true);
         $property->setValue($this->obj, $value);
     }
 }


### PR DESCRIPTION
## Beschreibung

`ReflectionMethod::setAccessible()` und `ReflectionProperty::setAccessible()` haben seit **PHP 8.1** keine Wirkung mehr (Reflection kann ohnehin auf `private`/`protected`-Member zugreifen) und sind seit **PHP 8.5** als deprecated markiert.

Unter PHP 8.5 löst das auf den MetaInfo-Seiten eine `ErrorException` über den `rex_error_handler` aus, sobald `FocuspointBoot::metainfoDefault()` via `FocuspointReflection::getPropertyValue()` auf eine geschützte Property zugreift — die MetaInfo-Verwaltung ist dadurch nicht mehr aufrufbar.

## Änderung

Die drei `setAccessible(true)`-Aufrufe in `lib/FocuspointReflection.php` entfernt (`executeMethod()`, `getPropertyValue()`, `setPropertyValue()`).

Die Änderung ist **verhaltensneutral** — der Zugriff auf nicht-öffentliche Member funktioniert seit PHP 8.1 auch ohne diese Aufrufe. Die Legacy-Alias-Klasse `focuspoint_reflection` erbt von `FocuspointReflection` und ist damit automatisch mit abgedeckt.

Getestet gegen `master` (identisch zu 4.2.3), `php -l` fehlerfrei.

Fixes #143